### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+os:
+- linux
+- osx
+language: cpp
+compiler:
+- gcc
+#- clang
+install: ./travis/install-deps.sh "${TRAVIS_OS_NAME}"
+script:
+#- ./travis/cppcheck_wrapper.sh ./src -I ./include --check-config
+- autoreconf -i && ./configure --enable-leveldb && make -j 2
+branches:
+  only:
+  - master
+  - develop

--- a/travis/cppcheck_wrapper.sh
+++ b/travis/cppcheck_wrapper.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# The goal is to remove the suppressed checks stepwise and fix the issues
+# in the same commit. Use cppcheck --inline-suppr for false positives.
+sup_warn="--suppress=nullPointer"
+sup_info="--suppress=ConfigurationNotChecked"
+sup_perf="--suppress=stlSize --suppress=redundantAssignment \
+          --suppress=passedByValue --suppress=postfixOperator"
+sup_style="--suppress=variableScope --suppress=unreadVariable \
+           --suppress=noCopyConstructor --suppress=unusedVariable \
+           --suppress=cstyleCast --suppress=multiCondition"
+suppress="$sup_warn $sup_info $sup_perf $sup_style"
+enabled="--enable=warning --enable=information --enable=performance \
+         --enable=portability --enable=missingInclude --enable=style"
+# Exit code '1' is returned if arguments are not valid or if no input
+# files are provided. Compare 'cppcheck --help'.
+cppcheck -f -q --error-exitcode=2 $enabled $suppress "$@"

--- a/travis/install-deps.sh
+++ b/travis/install-deps.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Install cppcheck on Ubuntu from source since we need a recent version.
+# Will not be needed once travis is updated to Ubuntu 14.04.
+install_cppcheck()
+{
+    git clone https://github.com/danmar/cppcheck.git
+    cd cppcheck
+    git checkout 1.65
+    make SRCDIR=build CFGDIR=/usr/share/cppcheck HAVE_RULES=no -j2
+    sudo make install
+    # On travis cppcheck ignores CFGDIR. Instead, it looks in $PWD. Compare
+    # strace output.
+    sudo install -m644 ./cfg/* ../
+}
+
+if [ $# -ne 1 ]; then
+    echo "Error: expected OS type argument." >&2
+    exit 1
+fi
+
+os=$1
+
+case "$os" in
+    osx)
+        brew update
+        brew install boost openssl leveldb cppcheck
+        brew link --force openssl
+		brew tap homebrew/versions
+		brew install gcc48
+		# Can be replaced back later if you prefer, but
+		# keeping the new g++ is a good idea.
+		ln -sf /usr/local/bin/g++-4.8 /usr/bin/g++
+        ;;
+    linux|"" )
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        sudo apt-get -qq update
+        sudo apt-get -qq install g++-4.8
+        sudo apt-get install libboost1.48-all-dev pkg-config libcurl4-openssl-dev libleveldb-dev libsnappy-dev
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+        install_cppcheck
+        ;;
+    *)
+        echo "Error: unknown OS '$os'" >&2
+        exit 1
+        ;;
+esac
+
+
+git clone https://github.com/bitcoin/secp256k1.git
+cd secp256k1
+aclocal
+autoreconf --install
+./configure
+make -j2
+sudo make install
+sudo ldconfig
+
+#leveldb in Ubuntu 12.04 is outdated
+git clone https://code.google.com/p/leveldb/
+cd leveldb
+make -j2
+sudo cp --preserve=links libleveldb.* /usr/local/lib
+sudo cp -r include/leveldb /usr/local/include/
+sudo ldconfig


### PR DESCRIPTION
Travis (www.travis-ci.org) is a really cool, free (for FOSS projects) CI, which you can activate with just one .travis.yml file in your github repo. We use it in the Open Transactions project and Conformal uses it for btcd, so I though that would be usfull for libbitcoin too. 
Travis builds every pull requests and gives automated feedback on it. It also rebuilds the branch everytime something gets merged. For now I've set it to build master and develop.

You can build with gcc and clang on Linux and on Mac OS X (a repo owner has to send a request to the support for that). I've deactivated clang for now, since it seems to fail:  https://travis-ci.org/lclc/libbitcoin/jobs/27610296#L882

It has the option to do a cppcheck everytime, but I have that deactivated for now. The rules are not very strict ATM, see travis/cppcheck_wrapper.sh. Do you want a cppcheck by travis? Otherways I'll remove it.

It has to build cppcheck and leveldb, since both are outdated in 12.04.
I've also had to add a PPA with a C++11 compiler, since that is outdated in 12.04 too. I hope they will switch to 14.04 or something else soon, but till then this works (just takes a few minutes longer)

The 12.04 / 14.04 Github Issue for Travis:
https://github.com/travis-ci/travis-ci/issues/2046

It takes about minutes to build with gcc.
The build for this commit on my repo: https://travis-ci.org/lclc/libbitcoin/builds/27616384

To activate Travis, you have to merge this PR and one of the repo owners have to activate it here: https://travis-ci.org/profile
