### PR TITLE
README: add missing libssl-dev to a list of Debian packages required to ...

### DIFF
--- a/README
+++ b/README
@@ -14,7 +14,7 @@ Note that you need g++ 4.7 or higher. For this reason Ubuntu 12.04 and older are
 > Start Here! <
   ^^^^^^^^^^^
 
-  $ sudo apt-get install build-essential autoconf automake libtool libboost-all-dev pkg-config libcurl4-openssl-dev libleveldb-dev
+  $ sudo apt-get install build-essential autoconf automake libtool libboost-all-dev pkg-config libcurl4-openssl-dev libleveldb-dev libssl-dev
   $ autoreconf -i
   $ ./configure --enable-leveldb
   $ make


### PR DESCRIPTION
building under Debian fails because of missing package libssl.

Add missing libssl-dev to a list of Debian packages required to build in the README
