### PR TITLE
updated README with instructions about secp256k1 dependency for MacOSX

### DIFF
--- a/README
+++ b/README
@@ -120,6 +120,16 @@ environment variables before running the build process.
   CC=/usr/local/bin/gcc-4.7
   CXX=/usr/local/bin/g++-4.7
 
+You will need secp256k1 as a library dependency, if you don't have
+it already in your system this is how you get/build/install it from source code.
+
+  $ git clone https://github.com/bitcoin/secp256k1
+  $ cd secp256k1
+  $ ./autogen.sh
+  $ ./configure
+  $ make
+  $ sudo make install
+
 For Mac OSX Mountain Lion, you need to follow these brew commands:
 
   $ brew install boost openssl leveldb


### PR DESCRIPTION
kept getting this when building on mac

```
CXX      utility/ec_keys.lo
utility/ec_keys.cpp:22:23: fatal error: secp256k1.h: No such file or directory
 #include <secp256k1.h>
```
