### PR TITLE
Further configure rationalization

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -195,8 +195,14 @@ src_libbitcoin_la_LIBADD = \
     -lboost_regex \
     -lboost_filesystem \
     -lpthread \
-    ${secp256k1_LIBS}
-    
+    ${secp256k1_LIBS} \
+    ${gmp_LIBS}
+
+if USE_LIBRT
+src_libbitcoin_la_LIBADD += \
+    ${rt_LIBS}
+endif
+
 #
 # examples
 #
@@ -245,8 +251,7 @@ test_libbitcoin_test_LDADD = \
 
 if USE_LIBRT
 test_libbitcoin_test_LDADD += \
-    @rtlib@
-
+    ${rt_LIBS}
 endif
 
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -1,3 +1,5 @@
+AC_PREREQ(2.61)
+
 AC_INIT([libbitcoin], [2.5.0], [genjix@riseup.net])
 AC_USE_SYSTEM_EXTENSIONS
 AC_LANG(C++)
@@ -40,10 +42,14 @@ AX_BOOST_SYSTEM
 PKG_PROG_PKG_CONFIG
 
 # GMP does not publish a package config, so we do a header and library test.
-AC_CHECK_HEADER(gmp.h,,
-    [AC_MSG_ERROR([GMP header is required but was not found.])],-)
-AC_CHECK_LIB(gmp,__gmpz_init,,
-    [AC_MSG_ERROR([GMP library is required but was not found.])])
+AC_CHECK_HEADER([gmp.h],,
+    [ AC_MSG_ERROR([GMP header is required but was not found.]) ],-)
+
+AC_CHECK_LIB([gmp],[__gmpz_init],
+    [
+        AC_SUBST([gmp_LIBS], ["-lgmp"])
+    ],
+    [ AC_MSG_ERROR([GMP library is required but was not found.]) ])
 
 # TODO: We require secp256k1 to require GMP (over OpenSSL).
 PKG_CHECK_MODULES([secp256k1], [libsecp256k1 >= 0.0.1])
@@ -80,16 +86,18 @@ case ${host_os} in
 esac
 
 # librt conditional check
-librt_libs=""
+rt_LIBS=""
 
 if test "x$require_librt" != "xno"; then
     AC_CHECK_LIB([rt], [clock_gettime],
-        [ librt_libs="-lrt" ],
+        [
+            rt_LIBS="-lrt"
+        ],
         [ AC_MSG_ERROR([rt library is required but was not found.]) ])
 fi
 
-AM_CONDITIONAL(USE_LIBRT, test "x$librt_libs" != "x")
-AC_SUBST([rtlib], ["$librt_libs"])
+AM_CONDITIONAL(USE_LIBRT, test "x$rt_LIBS" != "x")
+AC_SUBST([rt_LIBS], ["$rt_LIBS"])
 
 # Do not add contextual build parameters in configuration.
 # http://stackoverflow.com/a/4680578

--- a/libbitcoin.pc.in
+++ b/libbitcoin.pc.in
@@ -15,6 +15,6 @@ Requires: libsecp256k1 >= 0.0.1
 Cflags: -I${includedir} -std=c++11
 
 # Our own lib and any we require that do not publish package configuration.
-Libs: -L${libdir} -lbitcoin -lgmp -lboost_date_time -lboost_filesystem \
-    -lboost_regex -lboost_system -lboost_unit_test_framework @rtlib@
+Libs: -L${libdir} -lbitcoin -lboost_date_time -lboost_filesystem \
+    -lboost_regex -lboost_system @gmp_LIBS@ @rt_LIBS@
 


### PR DESCRIPTION
Added minimum autoconf version check to match libzmq dependency.  After reading https://blog.flameeyes.eu/2008/04/i-consider-ac_check_lib-harmful altered use of AC_CHECK_LIB for gmp detection, rationalized names w.r.t. librt so as to mimic PKG_CHECK_MODULES.
