### PR TITLE
Make test assertions more transparent, resolve clang warnings.

### DIFF
--- a/test/amount.cpp
+++ b/test/amount.cpp
@@ -27,39 +27,37 @@ BOOST_AUTO_TEST_SUITE(parse_amount_tests)
 BOOST_AUTO_TEST_CASE(parse_amount_test)
 {
     const uint64_t invalid_amount = MAX_UINT64;
-    BOOST_REQUIRE(parse_amount("4.432") == 443200000);
-    BOOST_REQUIRE(parse_amount("4.432.") == invalid_amount);
-    BOOST_REQUIRE(parse_amount("4")  == 400000000);
-    BOOST_REQUIRE(parse_amount("4.") == 400000000);
-    BOOST_REQUIRE(parse_amount(".4") == 40000000);
-    BOOST_REQUIRE(parse_amount(".")  == 0);
-    BOOST_REQUIRE(parse_amount("0.00000004")  == 4);
-    BOOST_REQUIRE(parse_amount("0.000000044") == 4);
-    BOOST_REQUIRE(parse_amount("0.000000045") == 5);
-    BOOST_REQUIRE(parse_amount("0.000000049") == 5);
-    BOOST_REQUIRE(parse_amount("4.432112395") == 443211240);
-    BOOST_REQUIRE(parse_amount("21000000") == 2100000000000000);
-    BOOST_REQUIRE(parse_amount("1234.9", 0) == 1235);
-    BOOST_REQUIRE(parse_amount("64.25", 5) == 6425000);
+    BOOST_REQUIRE_EQUAL(parse_amount("4.432"), 443200000u);
+    BOOST_REQUIRE_EQUAL(parse_amount("4.432."), invalid_amount);
+    BOOST_REQUIRE_EQUAL(parse_amount("4"), 400000000u);
+    BOOST_REQUIRE_EQUAL(parse_amount("4."), 400000000u);
+    BOOST_REQUIRE_EQUAL(parse_amount(".4"), 40000000u);
+    BOOST_REQUIRE_EQUAL(parse_amount("."), 0u);
+    BOOST_REQUIRE_EQUAL(parse_amount("0.00000004"), 4u);
+    BOOST_REQUIRE_EQUAL(parse_amount("0.000000044"), 4u);
+    BOOST_REQUIRE_EQUAL(parse_amount("0.000000045"), 5u);
+    BOOST_REQUIRE_EQUAL(parse_amount("0.000000049"), 5u);
+    BOOST_REQUIRE_EQUAL(parse_amount("4.432112395"), 443211240u);
+    BOOST_REQUIRE_EQUAL(parse_amount("21000000"), 2100000000000000u);
+    BOOST_REQUIRE_EQUAL(parse_amount("1234.9", 0), 1235u);
+    BOOST_REQUIRE_EQUAL(parse_amount("64.25", 5), 6425000u);
 }
 
 BOOST_AUTO_TEST_CASE(parse_amount_overflow_test)
 {
     const uint64_t invalid_amount = MAX_UINT64;
-    BOOST_REQUIRE(parse_amount("9999999999999999999", 0) ==
-        9999999999999999999U);
-    BOOST_REQUIRE(parse_amount("18446744073709551614", 0) ==
-        18446744073709551614U);
-    BOOST_REQUIRE(parse_amount("18446744073709551615", 0) == invalid_amount);
-    BOOST_REQUIRE(parse_amount("18446744073709551616", 0) == invalid_amount);
-    BOOST_REQUIRE(parse_amount("99999999999999999999", 0) == invalid_amount);
+    BOOST_REQUIRE_EQUAL(parse_amount("9999999999999999999", 0), 9999999999999999999u);
+    BOOST_REQUIRE_EQUAL(parse_amount("18446744073709551614", 0), 18446744073709551614u);
+    BOOST_REQUIRE_EQUAL(parse_amount("18446744073709551615", 0), invalid_amount);
+    BOOST_REQUIRE_EQUAL(parse_amount("18446744073709551616", 0), invalid_amount);
+    BOOST_REQUIRE_EQUAL(parse_amount("99999999999999999999", 0), invalid_amount);
 }
 
 BOOST_AUTO_TEST_CASE(format_amount_test)
 {
-    BOOST_REQUIRE(format_amount(123, 0) == "123");
-    BOOST_REQUIRE(format_amount(123, 2) == "1.23");
-    BOOST_REQUIRE(format_amount(123, 4) == "0.0123");
+    BOOST_REQUIRE_EQUAL(format_amount(123, 0), "123");
+    BOOST_REQUIRE_EQUAL(format_amount(123, 2), "1.23");
+    BOOST_REQUIRE_EQUAL(format_amount(123, 4), "0.0123");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/base58.cpp
+++ b/test/base58.cpp
@@ -60,8 +60,7 @@ BOOST_AUTO_TEST_CASE(base58_test)
 
 BOOST_AUTO_TEST_CASE(is_b58)
 {
-    const std::string base58_chars =
-        "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    const std::string base58_chars = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
     for (char c: base58_chars)
     {
         BOOST_REQUIRE(is_base58(c));

--- a/test/checksum.cpp
+++ b/test/checksum.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(checksum_test)
 
     // Valid checksum:
     append_checksum(data);
-    BOOST_REQUIRE(data.size() == 8);
+    BOOST_REQUIRE_EQUAL(data.size(), 8u);
     BOOST_REQUIRE(verify_checksum(data));
 
     // Data corruption:

--- a/test/ec_keys.cpp
+++ b/test/ec_keys.cpp
@@ -35,10 +35,10 @@ BOOST_AUTO_TEST_SUITE(ec_keys_tests)
 BOOST_AUTO_TEST_CASE(secret_to_public_key_test)
 {
     ec_point compressed = secret_to_public_key(secret, true);
-    BOOST_REQUIRE(encode_hex(compressed) ==
+    BOOST_REQUIRE_EQUAL(encode_hex(compressed),
         "0309ba8621aefd3b6ba4ca6d11a4746e8df8d35d9b51b383338f627ba7fc732731");
     ec_point uncompressed = secret_to_public_key(secret, false);
-    BOOST_REQUIRE(encode_hex(uncompressed) ==
+    BOOST_REQUIRE_EQUAL(encode_hex(uncompressed),
         "0409ba8621aefd3b6ba4ca6d11a4746e8df8d35d9b51b383338f627ba7fc732731"
         "8c3a6ec6acd33c36328b8fb4349b31671bcd3a192316ea4f6236ee1ae4a7d8c9");
 }
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(ec_add_test)
     ec_point public_a = secret_to_public_key(secret_a, true);
 
     BOOST_REQUIRE(ec_add(secret_a, secret_b));
-    BOOST_REQUIRE(encode_hex(secret_a) ==
+    BOOST_REQUIRE_EQUAL(encode_hex(secret_a),
         "0404040000000000000000000000000000000000000000000000000000000000");
 
     BOOST_REQUIRE(ec_add(public_a, secret_b));
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(ec_multiply_test)
     ec_point public_a = secret_to_public_key(secret_a, true);
 
     BOOST_REQUIRE(ec_multiply(secret_a, secret_b));
-    BOOST_REQUIRE(secret_a[31] = 242);
+    BOOST_REQUIRE_EQUAL(secret_a[31], 242u);
 
     BOOST_REQUIRE(ec_multiply(public_a, secret_b));
     ec_point public_sum = secret_to_public_key(secret_a, true);

--- a/test/format.cpp
+++ b/test/format.cpp
@@ -52,20 +52,20 @@ BOOST_AUTO_TEST_CASE(encode_test_padded_round_trips_value)
 BOOST_AUTO_TEST_CASE(endian_test)
 {
     auto le = to_little_endian<uint32_t>(123456789);
-    BOOST_REQUIRE(from_little_endian<uint32_t>(le.begin()) == 123456789);
+    BOOST_REQUIRE_EQUAL(from_little_endian<uint32_t>(le.begin()), 123456789u);
 
     auto be = to_big_endian<uint32_t>(123456789);
-    BOOST_REQUIRE(from_big_endian<uint32_t>(be.begin()) == 123456789);
+    BOOST_REQUIRE_EQUAL(from_big_endian<uint32_t>(be.begin()), 123456789u);
 
     std::reverse(le.begin(), le.end());
-    BOOST_REQUIRE(from_big_endian<uint32_t>(le.begin()) == 123456789);
+    BOOST_REQUIRE_EQUAL(from_big_endian<uint32_t>(le.begin()), 123456789u);
 
     auto bytes = data_chunk{ 0xff };
-    BOOST_REQUIRE(from_big_endian<uint8_t>(bytes.begin()) == 0xff);
+    BOOST_REQUIRE_EQUAL(from_big_endian<uint8_t>(bytes.begin()), 255u);
 
     auto quad = to_little_endian<uint64_t>(0x1122334455667788);
-    BOOST_REQUIRE(from_little_endian<uint64_t>(quad.begin()) ==
-        0x1122334455667788);
+    BOOST_REQUIRE_EQUAL(from_little_endian<uint64_t>(quad.begin()),
+        0x1122334455667788u);
 }
 
 // btc_to_satoshi

--- a/test/hash.cpp
+++ b/test/hash.cpp
@@ -41,14 +41,15 @@ BOOST_AUTO_TEST_CASE(ripemd_hash_test)
     {
         data_chunk data = decode_hex(result.input);
         short_hash hash = decode_short_hash(result.result);
-        BOOST_REQUIRE(ripemd160_hash(data) == hash);
+        BOOST_REQUIRE_EQUAL(encode_hex(ripemd160_hash(data)),
+            encode_hex(hash));
     }
     auto ripemd_hash = bitcoin_short_hash(data_chunk{110});
-    BOOST_REQUIRE(encode_hex(ripemd_hash) ==
+    BOOST_REQUIRE_EQUAL(encode_hex(ripemd_hash),
         "17d040b739d639c729daaf627eaff88cfe4207f4");
     data_chunk foo = decode_hex(
         "020641fde3a85beb8321033516de7ec01c35de96e945bf76c3768784a905471986");
-    BOOST_REQUIRE(encode_hex(bitcoin_short_hash(foo)) ==
+    BOOST_REQUIRE_EQUAL(encode_hex(bitcoin_short_hash(foo)),
         "c23e37c6fad06deab545f952992c8f28cb02bbe5");
 }
 
@@ -58,7 +59,7 @@ BOOST_AUTO_TEST_CASE(sha256_hash_test)
     {
         data_chunk data = decode_hex(result.input);
         hash_digest hash = decode_hash(result.result);
-        BOOST_REQUIRE(sha256_hash(data) == hash);
+        BOOST_REQUIRE_EQUAL(encode_hex(sha256_hash(data)), encode_hex(hash));
     }
 
     // This changes based on ENABLE_TESTNET, so the test condition must vary.
@@ -67,10 +68,10 @@ BOOST_AUTO_TEST_CASE(sha256_hash_test)
     auto genesis_hash = hash_block_header(genesis.header);
 
 #ifdef ENABLE_TESTNET
-    BOOST_REQUIRE(encode_hex(genesis_hash) ==
+    BOOST_REQUIRE_EQUAL(encode_hex(genesis_hash),
         "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943");
 #else
-    BOOST_REQUIRE(encode_hex(genesis_hash) ==
+    BOOST_REQUIRE_EQUAL(encode_hex(genesis_hash),
         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
 #endif
 }
@@ -81,7 +82,7 @@ BOOST_AUTO_TEST_CASE(hmac_sha512_hash_test)
     data_chunk key{'k', 'e', 'y'};
 
     auto long_hash = hmac_sha512_hash(chunk, key);
-    BOOST_REQUIRE(encode_hex(long_hash) ==
+    BOOST_REQUIRE_EQUAL(encode_hex(long_hash),
         "3c5953a18f7303ec653ba170ae334fafa08e3846f2efe317b87efce82376253c"
         "b52a8c31ddcde5a3a2eee183c2b34cb91f85e64ddbc325f7692b199473579c58");
 }
@@ -91,7 +92,7 @@ BOOST_AUTO_TEST_CASE(sha512_hash_test)
     data_chunk chunk{'d', 'a', 't', 'a'};
 
     auto long_hash = sha512_hash(chunk);
-    BOOST_REQUIRE(encode_hex(long_hash) ==
+    BOOST_REQUIRE_EQUAL(encode_hex(long_hash),
         "77c7ce9a5d86bb386d443bb96390faa120633158699c8844c30b13ab0bf92760"
         "b7e4416aea397db91b4ac0e5dd56b8ef7e4b066162ab1fdc088319ce6defc876");
 }

--- a/test/hash_number.cpp
+++ b/test/hash_number.cpp
@@ -26,28 +26,27 @@ BOOST_AUTO_TEST_SUITE(hashnum_tests)
 
 BOOST_AUTO_TEST_CASE(simple)
 {
+    hash_number target;
+    uint32_t bits = 486604799;
+    target.set_compact(bits);
     hash_digest block_hash = decode_hash(
         "00000000b873e79784647a6c82962c70d228557d24a747ea4d1b8bbe878e1206");
-    uint32_t bits = 486604799;
 
-    hash_number target;
-    target.set_compact(bits);
-
-    BOOST_REQUIRE((target <= 0) == false);
-    BOOST_REQUIRE((target > max_target()) == false);
+    BOOST_REQUIRE(!(target <= 0));
+    BOOST_REQUIRE(!(target > max_target()));
 
     hash_number our_value;
     our_value.set_hash(block_hash);
-    BOOST_REQUIRE((our_value > target) == false);
+    BOOST_REQUIRE(!(our_value > target));
 }
 
 BOOST_AUTO_TEST_CASE(work)
 {
     hash_number orphan_work = 0;
-    BOOST_REQUIRE(orphan_work.hash() == null_hash);
+    BOOST_REQUIRE_EQUAL(encode_hex(orphan_work.hash()), encode_hex(null_hash));
     orphan_work += block_work(486604799);
-    BOOST_REQUIRE(orphan_work.hash() == decode_hash(
-        "0100010001000000000000000000000000000000000000000000000000000000"));
+    BOOST_REQUIRE_EQUAL(encode_hex(orphan_work.hash()),
+        "0100010001000000000000000000000000000000000000000000000000000000");
     hash_number main_work = 0;
     BOOST_REQUIRE(!(orphan_work <= main_work));
 }

--- a/test/hd_keys.cpp
+++ b/test/hd_keys.cpp
@@ -42,22 +42,22 @@ BOOST_AUTO_TEST_CASE(bip32_test_vector_1)
     auto m0h12h2  = m0h12h. generate_private_key(2);
     auto m0h12h2x = m0h12h2.generate_private_key(1000000000);
 
-    BITCOIN_ASSERT(m.encoded() ==
+    BOOST_REQUIRE_EQUAL(m.encoded(),
         "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPP"
         "qjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi");
-    BITCOIN_ASSERT(m0h.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0h.encoded(),
         "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvU"
         "xt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7");
-    BITCOIN_ASSERT(m0h1.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0h1.encoded(),
         "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLn"
         "vSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs");
-    BITCOIN_ASSERT(m0h12h.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0h12h.encoded(),
         "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBD"
         "ptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM");
-    BITCOIN_ASSERT(m0h12h2.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0h12h2.encoded(),
         "xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb"
         "2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334");
-    BITCOIN_ASSERT(m0h12h2x.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0h12h2x.encoded(),
         "xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8F"
         "Ha8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76");
 
@@ -70,23 +70,23 @@ BOOST_AUTO_TEST_CASE(bip32_test_vector_1)
     auto m0h12h2_pub  = m0h12h_pub. generate_public_key(2);
     auto m0h12h2x_pub = m0h12h2_pub.generate_public_key(1000000000);
 
-    BITCOIN_ASSERT(!m0h_bad.valid());
-    BITCOIN_ASSERT(m_pub.encoded() ==
+    BOOST_REQUIRE(!m0h_bad.valid());
+    BOOST_REQUIRE_EQUAL(m_pub.encoded(),
         "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhe"
         "PY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8");
-    BITCOIN_ASSERT(m0h_pub.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0h_pub.encoded(),
         "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEj"
         "WgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw");
-    BITCOIN_ASSERT(m0h1_pub.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0h1_pub.encoded(),
         "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3"
         "UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ");
-    BITCOIN_ASSERT(m0h12h_pub.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0h12h_pub.encoded(),
         "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VU"
         "NgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5");
-    BITCOIN_ASSERT(m0h12h2_pub.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0h12h2_pub.encoded(),
         "xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBq"
         "aGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV");
-    BITCOIN_ASSERT(m0h12h2x_pub.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0h12h2x_pub.encoded(),
         "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSV"
         "qNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy");
 }
@@ -115,22 +115,22 @@ BOOST_AUTO_TEST_CASE(bip32_test_vector_2)
     auto m0xH1yH  = m0xH1.  generate_private_key(2147483646 + hard);
     auto m0xH1yH2 = m0xH1yH.generate_private_key(2);
 
-    BITCOIN_ASSERT(m.encoded() ==
+    BOOST_REQUIRE_EQUAL(m.encoded(),
         "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtAL"
         "Gdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U");
-    BITCOIN_ASSERT(m0.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0.encoded(),
         "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQ"
         "RUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt");
-    BITCOIN_ASSERT(m0xH.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0xH.encoded(),
         "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vi"
         "dYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9");
-    BITCOIN_ASSERT(m0xH1.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0xH1.encoded(),
         "xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTR"
         "XSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef");
-    BITCOIN_ASSERT(m0xH1yH.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0xH1yH.encoded(),
         "xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS"
         "3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc");
-    BITCOIN_ASSERT(m0xH1yH2.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0xH1yH2.encoded(),
         "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKC"
         "EXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j");
 
@@ -142,22 +142,22 @@ BOOST_AUTO_TEST_CASE(bip32_test_vector_2)
     auto m0xH1yH_pub  = m0xH1.      generate_public_key(2147483646 + hard);
     auto m0xH1yH2_pub = m0xH1yH_pub.generate_public_key(2);
 
-    BITCOIN_ASSERT(m_pub.encoded() ==
+    BOOST_REQUIRE_EQUAL(m_pub.encoded(),
         "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUa"
         "pSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB");
-    BITCOIN_ASSERT(m0_pub.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0_pub.encoded(),
         "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9Lgpe"
         "yGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH");
-    BITCOIN_ASSERT(m0xH_pub.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0xH_pub.encoded(),
         "xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEy"
         "BLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a");
-    BITCOIN_ASSERT(m0xH1_pub.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0xH1_pub.encoded(),
         "xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg"
         "5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon");
-    BITCOIN_ASSERT(m0xH1yH_pub.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0xH1yH_pub.encoded(),
         "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhg"
         "bmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL");
-    BITCOIN_ASSERT(m0xH1yH2_pub.encoded() ==
+    BOOST_REQUIRE_EQUAL(m0xH1yH2_pub.encoded(),
         "xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdS"
         "nLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt");
 }

--- a/test/key_formats.cpp
+++ b/test/key_formats.cpp
@@ -46,8 +46,8 @@ BOOST_AUTO_TEST_CASE(wif_test)
         "5JngqQmHagNTknnCshzVUysLMWAjT23FWs1TgNU5wyFH5SB3hrP";
 #endif
 
-    BOOST_REQUIRE(secret_to_wif(secret, true) == compressed);
-    BOOST_REQUIRE(secret_to_wif(secret, false) == uncompressed);
+    BOOST_REQUIRE_EQUAL(secret_to_wif(secret, true), compressed);
+    BOOST_REQUIRE_EQUAL(secret_to_wif(secret, false), uncompressed);
 
     BOOST_REQUIRE(is_wif_compressed(compressed));
     BOOST_REQUIRE(!is_wif_compressed(uncompressed));

--- a/test/script.cpp
+++ b/test/script.cpp
@@ -123,7 +123,7 @@ void push_data(data_chunk& raw_script, const data_chunk& data)
         op.code = opcode::pushdata2;
     else
     {
-        BITCOIN_ASSERT(data.size() <= 0xffffffff);
+        BOOST_REQUIRE_LE(data.size(), 0xffffffffu);
         op.code = opcode::pushdata4;
     }
     op.data = data;

--- a/test/script_number.cpp
+++ b/test/script_number.cpp
@@ -135,18 +135,18 @@ static void CheckCompare(const int64_t num1, const int64_t num2,
     BOOST_CHECK(!(scriptnum1 > num1));
 
     BOOST_CHECK_EQUAL(is(compare.eq), (scriptnum1 == scriptnum2));
+    BOOST_CHECK_EQUAL(is(compare.ge), (scriptnum1 >= scriptnum2));
+    BOOST_CHECK_EQUAL(is(compare.le), (scriptnum1 <= scriptnum2));
     BOOST_CHECK_EQUAL(is(compare.ne), (scriptnum1 != scriptnum2));
     BOOST_CHECK_EQUAL(is(compare.lt), (scriptnum1 < scriptnum2));
     BOOST_CHECK_EQUAL(is(compare.gt), (scriptnum1 > scriptnum2));
-    BOOST_CHECK_EQUAL(is(compare.ge), (scriptnum1 >= scriptnum2));
-    BOOST_CHECK_EQUAL(is(compare.le), (scriptnum1 <= scriptnum2));
-
+    
     BOOST_CHECK_EQUAL(is(compare.eq), (scriptnum1 == num2));
+    BOOST_CHECK_EQUAL(is(compare.ge), (scriptnum1 >= num2));
+    BOOST_CHECK_EQUAL(is(compare.le), (scriptnum1 <= num2));
     BOOST_CHECK_EQUAL(is(compare.ne), (scriptnum1 != num2));
     BOOST_CHECK_EQUAL(is(compare.lt), (scriptnum1 < num2));
     BOOST_CHECK_EQUAL(is(compare.gt), (scriptnum1 > num2));
-    BOOST_CHECK_EQUAL(is(compare.ge), (scriptnum1 >= num2));
-    BOOST_CHECK_EQUAL(is(compare.le), (scriptnum1 <= num2));
 }
 
 #ifndef ENABLE_DATAGEN

--- a/test/serialize.cpp
+++ b/test/serialize.cpp
@@ -29,15 +29,24 @@ BOOST_AUTO_TEST_CASE(serialize_test)
     const std::string rawdat_repr =
         "46682488f0a721124a3905a1bb72445bf13493e2cd46c5c0c8db1c15afa0d58e00000000";
     data_chunk rawdat(decode_hex(rawdat_repr));
-    BOOST_REQUIRE(rawdat == (data_chunk{0x46, 0x68, 0x24, 0x88, 0xf0, 0xa7,
-                0x21, 0x12, 0x4a, 0x39, 0x05, 0xa1, 0xbb, 0x72, 0x44, 0x5b,
-                0xf1, 0x34, 0x93, 0xe2, 0xcd, 0x46, 0xc5, 0xc0, 0xc8, 0xdb,
-                0x1c, 0x15, 0xaf, 0xa0, 0xd5, 0x8e, 0x00, 0x00, 0x00, 0x00}));
+    BOOST_REQUIRE(rawdat == (data_chunk
+    {
+        0x46, 0x68, 0x24, 0x88, 0xf0, 0xa7, 0x21, 0x12, 0x4a, 0x39, 0x05, 0xa1,
+        0xbb, 0x72, 0x44, 0x5b, 0xf1, 0x34, 0x93, 0xe2, 0xcd, 0x46, 0xc5, 0xc0,
+        0xc8, 0xdb, 0x1c, 0x15, 0xaf, 0xa0, 0xd5, 0x8e, 0x00, 0x00, 0x00, 0x00
+    }));
     auto deserial = make_deserializer(rawdat.begin(), rawdat.end());
     output_point outpoint;
     outpoint.hash = deserial.read_hash();
     outpoint.index = deserial.read_4_bytes();
-    BOOST_REQUIRE(outpoint.hash == (hash_digest{{0x8e, 0xd5, 0xa0, 0xaf, 0x15, 0x1c, 0xdb, 0xc8, 0xc0, 0xc5, 0x46, 0xcd, 0xe2, 0x93, 0x34, 0xf1, 0x5b, 0x44, 0x72, 0xbb, 0xa1, 0x05, 0x39, 0x4a, 0x12, 0x21, 0xa7, 0xf0, 0x88, 0x24, 0x68, 0x46}}));
+    BOOST_REQUIRE(outpoint.hash == (hash_digest
+    {
+        {
+            0x8e, 0xd5, 0xa0, 0xaf, 0x15, 0x1c, 0xdb, 0xc8, 0xc0, 0xc5, 0x46,
+            0xcd, 0xe2, 0x93, 0x34, 0xf1, 0x5b, 0x44, 0x72, 0xbb, 0xa1, 0x05, 
+            0x39, 0x4a, 0x12, 0x21, 0xa7, 0xf0, 0x88, 0x24, 0x68, 0x46
+        }
+    }));
     BOOST_REQUIRE(outpoint.index == 0);
     data_chunk buff(36);
     auto serial = make_serializer(buff.begin());
@@ -52,10 +61,10 @@ BOOST_AUTO_TEST_CASE(genesis_block_serialize_test)
     BOOST_REQUIRE_EQUAL(satoshi_raw_size(genblk), 285u);
     BOOST_REQUIRE_EQUAL(satoshi_raw_size(genblk.header), 80u);
     data_chunk rawblk(285);
-    BOOST_REQUIRE_EQUAL(std::distance(rawblk.begin(), rawblk.end()), 285);
+    BOOST_REQUIRE_EQUAL(std::distance(rawblk.begin(), rawblk.end()), 285u);
     // Save genesis block.
     auto end_iter = satoshi_save(genblk, rawblk.begin());
-    BOOST_REQUIRE_EQUAL(std::distance(rawblk.begin(), end_iter), 285);
+    BOOST_REQUIRE_EQUAL(std::distance(rawblk.begin(), end_iter), 285u);
     BOOST_REQUIRE(end_iter == rawblk.end());
     // Reload genesis block.
     block_type blk;
@@ -87,12 +96,12 @@ BOOST_AUTO_TEST_CASE(tx_test)
         "001976a914d9d78e26df4e4601cf9b26d09c7b280ee764469f88ac80c4600f00"
         "0000001976a9141ee32412020a324b93b1a1acfdfff6ab9ca8fac288ac000000"
         "00");
-    BOOST_REQUIRE(raw_tx_1.size() == 225);
+    BOOST_REQUIRE_EQUAL(raw_tx_1.size(), 225u);
     transaction_type tx_1;
     satoshi_load(raw_tx_1.begin(), raw_tx_1.end(), tx_1);
     BOOST_REQUIRE(hash_transaction(tx_1) == tx_hash_1);
     // Re-save tx and compare against original.
-    BOOST_REQUIRE(satoshi_raw_size(tx_1) == raw_tx_1.size());
+    BOOST_REQUIRE_EQUAL(satoshi_raw_size(tx_1), raw_tx_1.size());
     data_chunk resave_1(satoshi_raw_size(tx_1));
     satoshi_save(tx_1, resave_1.begin());
     BOOST_REQUIRE(resave_1 == raw_tx_1);
@@ -117,7 +126,7 @@ BOOST_AUTO_TEST_CASE(tx_test)
         "ffff02c0e1e400000000001976a914884c09d7e1f6420976c40e040c30b2b622"
         "10c3d488ac20300500000000001976a914905f933de850988603aafeeb2fd7fc"
         "e61e66fe5d88ac00000000");
-    BOOST_REQUIRE(raw_tx_2.size() == 523);
+    BOOST_REQUIRE_EQUAL(raw_tx_2.size(), 523u);
     transaction_type tx_2;
     satoshi_load(raw_tx_2.begin(), raw_tx_2.end(), tx_2);
     BOOST_REQUIRE(hash_transaction(tx_2) == tx_hash_2);
@@ -166,7 +175,7 @@ BOOST_AUTO_TEST_CASE(script_parse_save_test)
 
 BOOST_AUTO_TEST_CASE(serialize_deserialize)
 {
-    data_chunk data(1+2+4+8+4+4+3+7);
+    data_chunk data(1 + 2 + 4 + 8 + 4 + 4 + 3 + 7);
     auto s = make_serializer(data.begin());
     s.write_byte(0x80);
     s.write_2_bytes(0x8040);
@@ -177,15 +186,15 @@ BOOST_AUTO_TEST_CASE(serialize_deserialize)
     s.write_data(to_data_chunk(to_little_endian<uint32_t>(0xbadf00d)));
     s.write_string("hello");
     auto ds = make_deserializer(data.begin(), s.iterator());
-    BOOST_REQUIRE(ds.read_byte() == 0x80);
-    BOOST_REQUIRE(ds.read_2_bytes() == 0x8040);
-    BOOST_REQUIRE(ds.read_4_bytes() == 0x80402010);
-    BOOST_REQUIRE(ds.read_8_bytes() == 0x8040201011223344);
-    BOOST_REQUIRE(ds.read_big_endian<uint32_t>() == 0x80402010);
-    BOOST_REQUIRE(ds.read_variable_uint() == 1234);
-    BOOST_REQUIRE(from_little_endian<uint32_t>(
-        ds.read_data(4).begin()) == 0xbadf00d);
-    BOOST_REQUIRE(ds.read_string() == "hello");
+    BOOST_REQUIRE_EQUAL(ds.read_byte(), 0x80u);
+    BOOST_REQUIRE_EQUAL(ds.read_2_bytes(), 0x8040u);
+    BOOST_REQUIRE_EQUAL(ds.read_4_bytes(), 0x80402010u);
+    BOOST_REQUIRE_EQUAL(ds.read_8_bytes(), 0x8040201011223344u);
+    BOOST_REQUIRE_EQUAL(ds.read_big_endian<uint32_t>(),  0x80402010u);
+    BOOST_REQUIRE_EQUAL(ds.read_variable_uint(), 1234u);
+    BOOST_REQUIRE_EQUAL(from_little_endian<uint32_t>(ds.read_data(4).begin()),
+        0xbadf00du);
+    BOOST_REQUIRE_EQUAL(ds.read_string(), "hello");
     BOOST_REQUIRE_THROW(ds.read_byte(), end_of_stream);
 }
 

--- a/test/stealth_address.cpp
+++ b/test/stealth_address.cpp
@@ -41,19 +41,19 @@ BOOST_AUTO_TEST_CASE(stealth_address_test)
         220, 193, 37, 11, 81, 192, 240, 58, 228, 233, 120, 224, 37, 110, 222,
         81, 220, 17, 68, 227, 69, 201, 38, 38, 43, 151, 23, 177, 188, 201,
         189, 27}};
-    BOOST_REQUIRE(ephem_privkey.size() == ec_secret_size);
-    BOOST_REQUIRE(scan_privkey.size() == ec_secret_size);
-    BOOST_REQUIRE(spend_privkey.size() == ec_secret_size);
+    BOOST_REQUIRE_EQUAL(ephem_privkey.size(), ec_secret_size);
+    BOOST_REQUIRE_EQUAL(scan_privkey.size(), ec_secret_size);
+    BOOST_REQUIRE_EQUAL(spend_privkey.size(), ec_secret_size);
     //ec_secret c{{
     //    75,73,116,38,110,230,200,190,217,239,242,205,16,135,187,193,16,31,23,
     //    186,217,195,120,20,248,86,27,103,245,80,197,68}};
 
     ec_point scan_pubkey = secret_to_public_key(scan_privkey);
-    BOOST_REQUIRE(scan_pubkey.size() == ec_compressed_size);
+    BOOST_REQUIRE_EQUAL(scan_pubkey.size(), ec_compressed_size);
     ec_point spend_pubkey = secret_to_public_key(spend_privkey);
-    BOOST_REQUIRE(spend_pubkey.size() == ec_compressed_size);
+    BOOST_REQUIRE_EQUAL(spend_pubkey.size(), ec_compressed_size);
     ec_point ephem_pubkey = secret_to_public_key(ephem_privkey);
-    BOOST_REQUIRE(ephem_pubkey.size() == ec_compressed_size);
+    BOOST_REQUIRE_EQUAL(ephem_pubkey.size(), ec_compressed_size);
 
     // Sender
     ec_point pubkey_1 = initiate_stealth(
@@ -79,9 +79,9 @@ BOOST_AUTO_TEST_CASE(stealth_address_test)
     auto foo = payaddr.encoded();
 
 #ifdef ENABLE_TESTNET
-    BOOST_REQUIRE(payaddr.encoded() == "mwSnRsXSEq3d7LTGqe7AtJYNqhATwHdhMb");
+    BOOST_REQUIRE_EQUAL(payaddr.encoded(), "mwSnRsXSEq3d7LTGqe7AtJYNqhATwHdhMb");
 #else
-    BOOST_REQUIRE(payaddr.encoded() == "1Gvq8pSTRocNLDyf858o4PL3yhZm5qQDgB");
+    BOOST_REQUIRE_EQUAL(payaddr.encoded(), "1Gvq8pSTRocNLDyf858o4PL3yhZm5qQDgB");
 #endif
 }
 
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(stealth_address__encoding__scan_mainnet__round_trips)
         "MSad5KyPbve7uyH6eswYAxLHRVSbWgNUeoGuXp";
     stealth_address address;
     address.set_encoded(encoded);
-    BOOST_REQUIRE(address.encoded() == encoded);
+    BOOST_REQUIRE_EQUAL(address.encoded(), encoded);
 }
 
 BOOST_AUTO_TEST_CASE(stealth_address__encoding__scan_testnet__round_trips)
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(stealth_address__encoding__scan_testnet__round_trips)
         "91Vpvshm2TDER8b9ZryuZ8VSzz8ywzNzX8NqF4";
     stealth_address address;
     address.set_encoded(encoded);
-    BOOST_REQUIRE(address.encoded() == encoded);
+    BOOST_REQUIRE_EQUAL(address.encoded(), encoded);
 }
 
 BOOST_AUTO_TEST_CASE(stealth_address__encoding__scan_pub_mainnet__round_trips)
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(stealth_address__encoding__scan_pub_mainnet__round_trips)
         "hfFGUXFPKkQ5M6LC6aEUKMsURdhw93bUdYdacEtBA8XttLv7evZkira2i";
     stealth_address address;
     address.set_encoded(encoded);
-    BOOST_REQUIRE(address.encoded() == encoded);
+    BOOST_REQUIRE_EQUAL(address.encoded(), encoded);
 }
 
 BOOST_AUTO_TEST_CASE(stealth_address__encoding__scan_pub_testnet__round_trip)
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(stealth_address__encoding__scan_pub_testnet__round_trip)
         "idPayBqZUpZH7Y5GTaoEyGxDsEmU377JUmhtqG8yoHCkfGfhnAHmGUJbL";
     stealth_address address;
     address.set_encoded(encoded);
-    BOOST_REQUIRE(address.encoded() == encoded);
+    BOOST_REQUIRE_EQUAL(address.encoded(), encoded);
 }
 
 BOOST_AUTO_TEST_CASE(prefix_to_string__32_bits__little_endian)
@@ -136,14 +136,14 @@ BOOST_AUTO_TEST_CASE(string_to_prefix__32_bits__little_endian)
     std::stringstream stream;
     stream << "10111010101011011111000000001101";
     stealth_prefix prefix(stream.str());
-    BOOST_REQUIRE_EQUAL(prefix.to_ulong(), 0xbaadf00d);
+    BOOST_REQUIRE_EQUAL(prefix.to_ulong(), 0xbaadf00du);
 }
 
 BOOST_AUTO_TEST_CASE(bytes_to_prefix__32_bits__ittle_endian)
 {
     data_chunk bytes({ 0x0d, 0xf0, 0xad, 0xba });
     auto prefix = bytes_to_prefix(32, bytes);
-    BOOST_REQUIRE_EQUAL(prefix.to_ulong(), 0xbaadf00d);
+    BOOST_REQUIRE_EQUAL(prefix.to_ulong(), 0xbaadf00du);
 }
 
 BOOST_AUTO_TEST_CASE(prefix_to_bytes__32_bits__little_endian)
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(bytes_to_prefix__two_bytes_leading_null_byte__round_trips)
     stream << prefix;
     BOOST_REQUIRE_EQUAL(prefix.size(), 16u);
     BOOST_REQUIRE_EQUAL(prefix.num_blocks(), 2u);
-    BOOST_REQUIRE_EQUAL(prefix.to_ulong(), 0x000000FF);
+    BOOST_REQUIRE_EQUAL(prefix.to_ulong(), 255u);
     BOOST_REQUIRE_EQUAL(stream.str(), "0000000011111111");
 }
 
@@ -244,8 +244,8 @@ BOOST_AUTO_TEST_CASE(prefix_to_bytes__two_bytes_leading_null_byte__round_trips)
     std::stringstream stream;
     stream << prefix;
     BOOST_REQUIRE_EQUAL(prefix.size(), 16u);
-    BOOST_REQUIRE_EQUAL(prefix.num_blocks(), 2);
-    BOOST_REQUIRE_EQUAL(bytes.size(), 2);
+    BOOST_REQUIRE_EQUAL(prefix.num_blocks(), 2u);
+    BOOST_REQUIRE_EQUAL(bytes.size(), 2u);
     BOOST_REQUIRE_EQUAL(stream.str(), "0000000011111111");
 }
 

--- a/test/uri.cpp
+++ b/test/uri.cpp
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(uri_write_test)
     writer.write_message("hello bitcoin");
     writer.write_r("http://example.com?purchase=shoes&user=bob");
 
-    BOOST_REQUIRE(writer.string() ==
+    BOOST_REQUIRE_EQUAL(writer.string(),
         "bitcoin:113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD?"
         "amount=0.0012&amount=100&"
         "label=%26%3D%0A&"


### PR DESCRIPTION
More explicit assertions provide more informative test failure information. CLang warns in the boost comparative test assertions when integer signs differ, including when an unsigned is compared with an unannotated literal - resolved with annotation.
