### PR TITLE
fix build break; accomodate secp256k1 breaking API change

### DIFF
--- a/src/utility/ec_keys.cpp
+++ b/src/utility/ec_keys.cpp
@@ -62,7 +62,7 @@ BC_API ec_point secret_to_public_key(const ec_secret& secret,
 
     ec_point out(size);
     int out_size;
-    if (!secp256k1_ecdsa_pubkey_create(out.data(), &out_size, secret.data(),
+    if (!secp256k1_ec_pubkey_create(out.data(), &out_size, secret.data(),
             compressed))
         return ec_point();
     BITCOIN_ASSERT(size == static_cast<size_t>(out_size));
@@ -72,13 +72,13 @@ BC_API ec_point secret_to_public_key(const ec_secret& secret,
 BC_API bool verify_public_key(const ec_point& public_key)
 {
     init.init();
-    return secp256k1_ecdsa_pubkey_verify(public_key.data(), public_key.size());
+    return secp256k1_ec_pubkey_verify(public_key.data(), public_key.size());
 }
 
 BC_API bool verify_private_key(const ec_secret& private_key)
 {
     init.init();
-    return secp256k1_ecdsa_seckey_verify(private_key.data());
+    return secp256k1_ec_seckey_verify(private_key.data());
 }
 
 BC_API data_chunk sign(ec_secret secret, hash_digest hash, ec_secret nonce)
@@ -112,26 +112,25 @@ BC_API bool verify_signature(const ec_point& public_key, hash_digest hash,
 BC_API bool ec_tweak_add(ec_point& a, const ec_secret& b)
 {
     init.init();
-    return secp256k1_ecdsa_pubkey_tweak_add(a.data(), a.size(), b.data());
+    return secp256k1_ec_pubkey_tweak_add(a.data(), a.size(), b.data());
 }
 
 BC_API bool ec_multiply(ec_point& a, const ec_secret& b)
 {
     init.init();
-    return secp256k1_ecdsa_pubkey_tweak_mul(a.data(), a.size(), b.data());
+    return secp256k1_ec_pubkey_tweak_mul(a.data(), a.size(), b.data());
 }
 
 BC_API bool ec_add(ec_secret& a, const ec_secret& b)
 {
     init.init();
-    return secp256k1_ecdsa_privkey_tweak_add(a.data(), b.data());
+    return secp256k1_ec_privkey_tweak_add(a.data(), b.data());
 }
 
 BC_API bool ec_multiply(ec_secret& a, const ec_secret& b)
 {
     init.init();
-    return secp256k1_ecdsa_privkey_tweak_mul(a.data(), b.data());
+    return secp256k1_ec_privkey_tweak_mul(a.data(), b.data());
 }
 
 } // namespace libbitcoin
-


### PR DESCRIPTION
The present commit un-breaks the `install-sx.sh` script on the [`spesmilo/sx` repo](https://github.com/spesmilo/sx). This build break was [fixed a month ago in the version2 branch](https://github.com/libbitcoin/libbitcoin/commit/aa39fd68b9042a341ae8a50bcd5941327a55acac) by @evoskuil but it was never fixed in the master branch.  

For those of us who cannot wait for the [new libbitcoin-server](https://github.com/libbitcoin/libbitcoin-server) to be released the [only option is obelisk/master compiled against libbitcoin/master](https://github.com/libbitcoin/obelisk/issues/11#issuecomment-64822910).  The present commit should make life easier for others foolish enough to try it.
