### PR TITLE
Base16 array

### DIFF
--- a/include/bitcoin/bitcoin/formats/base16.hpp
+++ b/include/bitcoin/bitcoin/formats/base16.hpp
@@ -40,6 +40,13 @@ BC_API std::string encode_base16(data_slice data);
 BC_API bool decode_base16(data_chunk& out, const std::string &in);
 
 /**
+ * Converts a hex string to a number of bytes.
+ * @return false if the input is malformed, or the wrong length.
+ */
+template <size_t Size>
+bool decode_base16(byte_array<Size>& out, const std::string &in);
+
+/**
  * Converts a hex string literal to a data array.
  * This would be better as a C++11 user-defined literal,
  * but MSVC doesn't support those.
@@ -48,29 +55,10 @@ template <size_t Size>
 byte_array<(Size - 1) / 2> base16_literal(const char (&string)[Size]);
 
 /**
- * Converts a short_hash to a string.
- * The short_hash format is base16.
- */
-BC_API std::string encode_hash(short_hash hash);
-
-/**
  * Converts a bitcoin_hash to a string.
  * The bitcoin_hash format is like base16, but with the bytes reversed.
  */
 BC_API std::string encode_hash(hash_digest hash);
-
-/**
- * Converts a long_hash to a string.
- * The short_hash format is base16.
- */
-BC_API std::string encode_hash(long_hash hash);
-
-/**
- * Convert a string into a short_hash.
- * The short_hash format is base16.
- * @return false if the input is malformed.
- */
-BC_API bool decode_hash(short_hash& out, const std::string& in);
 
 /**
  * Convert a string into a bitcoin_hash.
@@ -78,13 +66,6 @@ BC_API bool decode_hash(short_hash& out, const std::string& in);
  * @return false if the input is malformed.
  */
 BC_API bool decode_hash(hash_digest& out, const std::string& in);
-
-/**
- * Convert a string into a long_hash.
- * The long_hash format is base16.
- * @return false if the input is malformed.
- */
-BC_API bool decode_hash(long_hash& out, const std::string& in);
 
 /**
  * Convert a hex string literal into a bitcoin_hash.

--- a/include/bitcoin/bitcoin/impl/formats/base16.ipp
+++ b/include/bitcoin/bitcoin/impl/formats/base16.ipp
@@ -30,6 +30,20 @@ namespace libbitcoin {
  */
 BC_API bool decode_base16_private(uint8_t* out, size_t out_size, const char* in);
 
+template <size_t Size>
+bool decode_base16(byte_array<Size>& out, const std::string &in)
+{
+    if (in.size() != 2 * Size)
+        return false;
+
+    byte_array<Size> result;
+    if (!decode_base16_private(result.data(), result.size(), in.data()))
+        return false;
+
+    out = result;
+    return true;
+}
+
 template<size_t Size>
 byte_array<(Size - 1) / 2> base16_literal(const char (&string)[Size])
 {

--- a/src/formats/base16.cpp
+++ b/src/formats/base16.cpp
@@ -78,32 +78,10 @@ bool decode_base16(data_chunk& out, const std::string& in)
     return true;
 }
 
-std::string encode_hash(short_hash hash)
-{
-    return encode_base16(hash);
-}
-
+// Bitcoin hash format (these are all reversed):
 std::string encode_hash(hash_digest hash)
 {
     return encode_base16(hash);
-}
-
-std::string encode_hash(long_hash hash)
-{
-    return encode_base16(hash);
-}
-
-bool decode_hash(short_hash& out, const std::string& in)
-{
-    if (in.size() != 2 * short_hash_size)
-        return false;
-
-    short_hash result;
-    if (!decode_base16_private(result.data(), result.size(), in.data()))
-        return false;
-
-    out = result;
-    return true;
 }
 
 bool decode_hash(hash_digest& out, const std::string& in)
@@ -119,19 +97,6 @@ bool decode_hash(hash_digest& out, const std::string& in)
     return true;
 }
 
-bool decode_hash(long_hash& out, const std::string& in)
-{
-    if (in.size() != 2 * long_hash_size)
-        return false;
-
-    long_hash result;
-    if (!decode_base16_private(result.data(), result.size(), in.data()))
-        return false;
-
-    out = result;
-    return true;
-}
-
 hash_digest hash_literal(const char (&string)[2 * hash_size + 1])
 {
     hash_digest out;
@@ -139,6 +104,7 @@ hash_digest hash_literal(const char (&string)[2 * hash_size + 1])
     return out;
 }
 
+// Old names for backwards-compatibility:
 std::string encode_hex(data_slice in)
 {
     return encode_base16(in);

--- a/test/base16.cpp
+++ b/test/base16.cpp
@@ -38,6 +38,20 @@ BOOST_AUTO_TEST_CASE(base16_odd_length_invalid_test)
     BOOST_REQUIRE(!decode_base16(data, hex_str));
 }
 
+BOOST_AUTO_TEST_CASE(base16_short_hash_test)
+{
+    const auto& hex_str = "f85beb6356d0813ddb0dbb14230a249fe931a135";
+    short_hash hash;
+    BOOST_REQUIRE(decode_base16(hash, hex_str));
+    BOOST_REQUIRE_EQUAL(encode_base16(hash), hex_str);
+
+    short_hash expected = {{
+       0xf8, 0x5b, 0xeb, 0x63, 0x56, 0xd0, 0x81, 0x3d, 0xdb, 0x0d,
+       0xbb, 0x14, 0x23, 0x0a, 0x24, 0x9f, 0xe9, 0x31, 0xa1, 0x35
+    }};
+    BOOST_REQUIRE(hash == expected);
+}
+
 // TODO: these should be tested for correctness, not just round-tripping.
 
 BOOST_AUTO_TEST_CASE(base16_round_trip_test)


### PR DESCRIPTION
This branch provides a decode_base16 template that works with all fixed-width hash data. So, a user can do this now:

```
short_hash address;
decode_base16(address, "...");

hash_digest sha256_hash;
decode_base16(sha256_hash, "...");

long_hash hd_stage;
decode_base16(hd_stage, "...");

hash_digest transaction_hash;
decode_hash(transaction_hash, "..."); // Same C++ type, different encoding!

ec_secret privkey;
decode_base16(privkey, "..."); // This is convenient too now
```

As we talked about on IRC, the C++ types don't distinguish between the special Bitcoin hash type and regular hashes that just happen to be 256 bits long. Until we fix this, the user just has to know which encoding to use with which data.

Once we do get strong typing, we can just provide a universal `decode` method that works with anything via overloads, and contains the knowledge of which low-level encoding goes with which high-level type:

```
bool decode(data160& out, const std::string& in) { return decode_base16(out, in); }
bool decode(data256& out, const std::string& in) { return decode_base16(out, in); }
bool decode(data512& out, const std::string& in) { return decode_base16(out, in); }
bool decode(btc256& out, const std::string& in) { return decode_hash(out, in); }
bool decode(ec_secret& out, const std::string& in) { return decode_base16(out, in); }
bool decode(message_signature& out, const std::string& in) { return decode_base64(out, in); }
...
```

We can do the same thing with a universal `encode` method.

This keeps the issue of low-level encoding (base16, base58, base64...) separate from the high-level canonical encoding of data types (bitcoin hashes use this, message_signatures use that, ec_signatures use something else).
