### PR TITLE
Add a method to return the output script from a payment address.

### DIFF
--- a/include/bitcoin/system/wallet/payment_address.hpp
+++ b/include/bitcoin/system/wallet/payment_address.hpp
@@ -94,6 +94,7 @@ public:
     /// Accessors.
     uint8_t version() const;
     const short_hash& hash() const;
+    chain::script output_script() const;
 
     /// Methods.
     payment to_payment() const;

--- a/src/wallet/payment_address.cpp
+++ b/src/wallet/payment_address.cpp
@@ -186,6 +186,22 @@ const short_hash& payment_address::hash() const
     return hash_;
 }
 
+chain::script payment_address::output_script() const
+{
+    switch (version_)
+    {
+        case 0:
+        case 111:
+            return chain::script::to_pay_key_hash_pattern(hash_);
+
+        case 5:
+        case 196:
+            return chain::script::to_pay_script_hash_pattern(hash_);
+    }
+
+    return {};
+}
+
 // Methods.
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
@evoskuil I think something like this will help simplify generating the output index hashes.  It's also directly applicable to a command like `script-from-address` (in bx).  Thoughts?