### PR TITLE
Add payment address parsing and tests for standard witness scripts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -221,6 +221,7 @@ src_libbitcoin_system_la_SOURCES = \
     src/wallet/stealth_receiver.cpp \
     src/wallet/stealth_sender.cpp \
     src/wallet/uri.cpp \
+    src/wallet/witness_address.cpp \
     src/wallet/parse_encrypted_keys/parse_encrypted_key.hpp \
     src/wallet/parse_encrypted_keys/parse_encrypted_key.ipp \
     src/wallet/parse_encrypted_keys/parse_encrypted_prefix.hpp \
@@ -366,7 +367,8 @@ test_libbitcoin_system_test_SOURCES = \
     test/wallet/stealth_receiver.cpp \
     test/wallet/stealth_sender.cpp \
     test/wallet/uri.cpp \
-    test/wallet/uri_reader.cpp
+    test/wallet/uri_reader.cpp \
+    test/wallet/witness_address.cpp
 
 endif WITH_TESTS
 
@@ -650,7 +652,8 @@ include_bitcoin_system_wallet_HEADERS = \
     include/bitcoin/system/wallet/stealth_receiver.hpp \
     include/bitcoin/system/wallet/stealth_sender.hpp \
     include/bitcoin/system/wallet/uri.hpp \
-    include/bitcoin/system/wallet/uri_reader.hpp
+    include/bitcoin/system/wallet/uri_reader.hpp \
+    include/bitcoin/system/wallet/witness_address.hpp
 
 
 # Custom make targets.

--- a/builds/cmake/CMakeLists.txt
+++ b/builds/cmake/CMakeLists.txt
@@ -504,6 +504,7 @@ add_library( ${CANONICAL_LIB_NAME}
     "../../src/wallet/stealth_receiver.cpp"
     "../../src/wallet/stealth_sender.cpp"
     "../../src/wallet/uri.cpp"
+    "../../src/wallet/witness_address.cpp"
     "../../src/wallet/parse_encrypted_keys/parse_encrypted_key.hpp"
     "../../src/wallet/parse_encrypted_keys/parse_encrypted_key.ipp"
     "../../src/wallet/parse_encrypted_keys/parse_encrypted_prefix.hpp"
@@ -718,7 +719,8 @@ if (with-tests)
         "../../test/wallet/stealth_receiver.cpp"
         "../../test/wallet/stealth_sender.cpp"
         "../../test/wallet/uri.cpp"
-        "../../test/wallet/uri_reader.cpp" )
+        "../../test/wallet/uri_reader.cpp"
+        "../../test/wallet/witness_address.cpp" )
 
     add_test( NAME libbitcoin-system-test COMMAND libbitcoin-system-test
             --run_test=*

--- a/builds/msvc/vs2013/libbitcoin-system-test/libbitcoin-system-test.vcxproj
+++ b/builds/msvc/vs2013/libbitcoin-system-test/libbitcoin-system-test.vcxproj
@@ -191,6 +191,7 @@
     <ClCompile Include="..\..\..\..\test\wallet\stealth_sender.cpp" />
     <ClCompile Include="..\..\..\..\test\wallet\uri.cpp" />
     <ClCompile Include="..\..\..\..\test\wallet\uri_reader.cpp" />
+    <ClCompile Include="..\..\..\..\test\wallet\witness_address.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\test\chain\script.hpp" />

--- a/builds/msvc/vs2013/libbitcoin-system-test/libbitcoin-system-test.vcxproj.filters
+++ b/builds/msvc/vs2013/libbitcoin-system-test/libbitcoin-system-test.vcxproj.filters
@@ -360,6 +360,9 @@
     <ClCompile Include="..\..\..\..\test\wallet\uri_reader.cpp">
       <Filter>src\wallet</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\test\wallet\witness_address.cpp">
+      <Filter>src\wallet</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\test\chain\script.hpp">

--- a/builds/msvc/vs2013/libbitcoin-system/libbitcoin-system.vcxproj
+++ b/builds/msvc/vs2013/libbitcoin-system/libbitcoin-system.vcxproj
@@ -285,6 +285,7 @@
     <ClCompile Include="..\..\..\..\src\wallet\stealth_receiver.cpp" />
     <ClCompile Include="..\..\..\..\src\wallet\stealth_sender.cpp" />
     <ClCompile Include="..\..\..\..\src\wallet\uri.cpp" />
+    <ClCompile Include="..\..\..\..\src\wallet\witness_address.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\bitcoin\system.hpp" />
@@ -486,6 +487,7 @@
     <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\stealth_sender.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\uri.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\uri_reader.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\witness_address.hpp" />
     <ClInclude Include="..\..\..\..\src\math\external\aes256.h" />
     <ClInclude Include="..\..\..\..\src\math\external\crypto_scrypt.h" />
     <ClInclude Include="..\..\..\..\src\math\external\hmac_sha256.h" />

--- a/builds/msvc/vs2013/libbitcoin-system/libbitcoin-system.vcxproj.filters
+++ b/builds/msvc/vs2013/libbitcoin-system/libbitcoin-system.vcxproj.filters
@@ -645,6 +645,9 @@
     <ClCompile Include="..\..\..\..\src\wallet\uri.cpp">
       <Filter>src\wallet</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wallet\witness_address.cpp">
+      <Filter>src\wallet</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\bitcoin\system.hpp">
@@ -1242,6 +1245,9 @@
       <Filter>include\bitcoin\system\wallet</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\uri_reader.hpp">
+      <Filter>include\bitcoin\system\wallet</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\witness_address.hpp">
       <Filter>include\bitcoin\system\wallet</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\src\math\external\aes256.h">

--- a/builds/msvc/vs2015/libbitcoin-system-test/libbitcoin-system-test.vcxproj
+++ b/builds/msvc/vs2015/libbitcoin-system-test/libbitcoin-system-test.vcxproj
@@ -191,6 +191,7 @@
     <ClCompile Include="..\..\..\..\test\wallet\stealth_sender.cpp" />
     <ClCompile Include="..\..\..\..\test\wallet\uri.cpp" />
     <ClCompile Include="..\..\..\..\test\wallet\uri_reader.cpp" />
+    <ClCompile Include="..\..\..\..\test\wallet\witness_address.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\test\chain\script.hpp" />

--- a/builds/msvc/vs2015/libbitcoin-system-test/libbitcoin-system-test.vcxproj.filters
+++ b/builds/msvc/vs2015/libbitcoin-system-test/libbitcoin-system-test.vcxproj.filters
@@ -360,6 +360,9 @@
     <ClCompile Include="..\..\..\..\test\wallet\uri_reader.cpp">
       <Filter>src\wallet</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\test\wallet\witness_address.cpp">
+      <Filter>src\wallet</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\test\chain\script.hpp">

--- a/builds/msvc/vs2015/libbitcoin-system/libbitcoin-system.vcxproj
+++ b/builds/msvc/vs2015/libbitcoin-system/libbitcoin-system.vcxproj
@@ -282,6 +282,7 @@
     <ClCompile Include="..\..\..\..\src\wallet\stealth_receiver.cpp" />
     <ClCompile Include="..\..\..\..\src\wallet\stealth_sender.cpp" />
     <ClCompile Include="..\..\..\..\src\wallet\uri.cpp" />
+    <ClCompile Include="..\..\..\..\src\wallet\witness_address.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\bitcoin\system.hpp" />
@@ -483,6 +484,7 @@
     <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\stealth_sender.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\uri.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\uri_reader.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\witness_address.hpp" />
     <ClInclude Include="..\..\..\..\src\math\external\aes256.h" />
     <ClInclude Include="..\..\..\..\src\math\external\crypto_scrypt.h" />
     <ClInclude Include="..\..\..\..\src\math\external\hmac_sha256.h" />

--- a/builds/msvc/vs2015/libbitcoin-system/libbitcoin-system.vcxproj.filters
+++ b/builds/msvc/vs2015/libbitcoin-system/libbitcoin-system.vcxproj.filters
@@ -639,6 +639,9 @@
     <ClCompile Include="..\..\..\..\src\wallet\uri.cpp">
       <Filter>src\wallet</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wallet\witness_address.cpp">
+      <Filter>src\wallet</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\bitcoin\system.hpp">
@@ -1236,6 +1239,9 @@
       <Filter>include\bitcoin\system\wallet</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\uri_reader.hpp">
+      <Filter>include\bitcoin\system\wallet</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\witness_address.hpp">
       <Filter>include\bitcoin\system\wallet</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\src\math\external\aes256.h">

--- a/builds/msvc/vs2017/libbitcoin-system-test/libbitcoin-system-test.vcxproj
+++ b/builds/msvc/vs2017/libbitcoin-system-test/libbitcoin-system-test.vcxproj
@@ -191,6 +191,7 @@
     <ClCompile Include="..\..\..\..\test\wallet\stealth_sender.cpp" />
     <ClCompile Include="..\..\..\..\test\wallet\uri.cpp" />
     <ClCompile Include="..\..\..\..\test\wallet\uri_reader.cpp" />
+    <ClCompile Include="..\..\..\..\test\wallet\witness_address.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\test\chain\script.hpp" />

--- a/builds/msvc/vs2017/libbitcoin-system-test/libbitcoin-system-test.vcxproj.filters
+++ b/builds/msvc/vs2017/libbitcoin-system-test/libbitcoin-system-test.vcxproj.filters
@@ -360,6 +360,9 @@
     <ClCompile Include="..\..\..\..\test\wallet\uri_reader.cpp">
       <Filter>src\wallet</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\test\wallet\witness_address.cpp">
+      <Filter>src\wallet</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\test\chain\script.hpp">

--- a/builds/msvc/vs2017/libbitcoin-system/libbitcoin-system.vcxproj
+++ b/builds/msvc/vs2017/libbitcoin-system/libbitcoin-system.vcxproj
@@ -282,6 +282,7 @@
     <ClCompile Include="..\..\..\..\src\wallet\stealth_receiver.cpp" />
     <ClCompile Include="..\..\..\..\src\wallet\stealth_sender.cpp" />
     <ClCompile Include="..\..\..\..\src\wallet\uri.cpp" />
+    <ClCompile Include="..\..\..\..\src\wallet\witness_address.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\bitcoin\system.hpp" />
@@ -483,6 +484,7 @@
     <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\stealth_sender.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\uri.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\uri_reader.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\witness_address.hpp" />
     <ClInclude Include="..\..\..\..\src\math\external\aes256.h" />
     <ClInclude Include="..\..\..\..\src\math\external\crypto_scrypt.h" />
     <ClInclude Include="..\..\..\..\src\math\external\hmac_sha256.h" />

--- a/builds/msvc/vs2017/libbitcoin-system/libbitcoin-system.vcxproj.filters
+++ b/builds/msvc/vs2017/libbitcoin-system/libbitcoin-system.vcxproj.filters
@@ -639,6 +639,9 @@
     <ClCompile Include="..\..\..\..\src\wallet\uri.cpp">
       <Filter>src\wallet</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wallet\witness_address.cpp">
+      <Filter>src\wallet</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\bitcoin\system.hpp">
@@ -1236,6 +1239,9 @@
       <Filter>include\bitcoin\system\wallet</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\uri_reader.hpp">
+      <Filter>include\bitcoin\system\wallet</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\system\wallet\witness_address.hpp">
       <Filter>include\bitcoin\system\wallet</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\src\math\external\aes256.h">

--- a/include/bitcoin/system.hpp
+++ b/include/bitcoin/system.hpp
@@ -212,5 +212,6 @@
 #include <bitcoin/system/wallet/stealth_sender.hpp>
 #include <bitcoin/system/wallet/uri.hpp>
 #include <bitcoin/system/wallet/uri_reader.hpp>
+#include <bitcoin/system/wallet/witness_address.hpp>
 
 #endif

--- a/include/bitcoin/system/chain/script.hpp
+++ b/include/bitcoin/system/chain/script.hpp
@@ -107,6 +107,7 @@ public:
     void to_data(writer& sink, bool prefix) const;
 
     std::string to_string(uint32_t active_forks) const;
+    hash_digest to_payments_key() const;
 
     // Iteration.
     //-------------------------------------------------------------------------

--- a/include/bitcoin/system/chain/script.hpp
+++ b/include/bitcoin/system/chain/script.hpp
@@ -191,6 +191,10 @@ public:
         const point_list& points);
     static operation::list to_pay_multisig_pattern(uint8_t signatures,
         const data_stack& points);
+    static operation::list to_pay_witness_key_hash_pattern(
+        const short_hash& hash);
+    static operation::list to_pay_witness_script_hash_pattern(
+        const hash_digest& hash);
 
     // Utilities (non-static).
     //-------------------------------------------------------------------------

--- a/include/bitcoin/system/wallet/payment_address.hpp
+++ b/include/bitcoin/system/wallet/payment_address.hpp
@@ -111,6 +111,8 @@ private:
     static payment_address from_script(const chain::script& script,
         uint8_t version);
 
+protected:
+
     /// Members.
     /// These should be const, apart from the need to implement assignment.
     bool valid_;

--- a/include/bitcoin/system/wallet/witness_address.hpp
+++ b/include/bitcoin/system/wallet/witness_address.hpp
@@ -51,7 +51,9 @@ public:
         mainnet_p2wsh,
         testnet_p2wpkh,
         testnet_p2wsh,
-     };
+
+        unknown
+    };
 
     static const uint8_t mainnet_p2sh_p2wpkh;
     static const uint8_t mainnet_p2sh_p2wsh;
@@ -80,31 +82,28 @@ public:
     witness_address(witness_address&& other);
     witness_address(const witness_address& other);
     witness_address(const witness_p2wpkh& decoded,
-        encoding out_type=encoding::mainnet_p2wpkh);
+        encoding out_type=encoding::unknown);
     witness_address(const witness_p2wsh& decoded,
-        encoding out_type=encoding::mainnet_p2wpkh);
+        encoding out_type=encoding::unknown);
     witness_address(const data_chunk& data,
-        encoding out_type=encoding::mainnet_p2wpkh);
+        encoding out_type=encoding::unknown);
     witness_address(const std::string& address,
-        encoding out_type=encoding::mainnet_p2wpkh);
-    witness_address(short_hash&& hash,
-        encoding out_type=encoding::mainnet_p2wpkh,
+        encoding out_type=encoding::unknown);
+    witness_address(short_hash&& hash, encoding out_type=encoding::unknown,
         uint8_t witness_version=0);
-    witness_address(const short_hash& hash,
-        encoding out_type=encoding::mainnet_p2wpkh,
+    witness_address(const short_hash& hash, encoding out_type=encoding::unknown,
         uint8_t witness_version=0);
-    witness_address(hash_digest&& hash,
-        encoding out_type=encoding::mainnet_p2wpkh,
+    witness_address(hash_digest&& hash, encoding out_type=encoding::unknown,
         uint8_t witness_version=0);
     witness_address(const hash_digest& hash,
-        encoding out_type=encoding::mainnet_p2wpkh,
+        encoding out_type=encoding::unknown,
         uint8_t witness_version=0);
     witness_address(const chain::script& script,
-        encoding out_type=encoding::mainnet_p2wpkh);
+        encoding out_type=encoding::unknown);
     witness_address(const ec_private& secret,
-        encoding out_type=encoding::mainnet_p2wpkh);
+        encoding out_type=encoding::unknown);
     witness_address(const ec_public& point,
-        encoding out_type=encoding::mainnet_p2wpkh);
+        encoding out_type=encoding::unknown);
 
     /// Operators.
     bool operator<(const witness_address& other) const;
@@ -133,19 +132,19 @@ private:
 
     /// Factories.
     static witness_address from_string(const std::string& address,
-        encoding out_type=encoding::mainnet_p2wpkh);
+        encoding out_type=encoding::unknown);
     static witness_address from_witness(const witness_p2wpkh& decoded,
-        encoding out_type=encoding::mainnet_p2wpkh);
+        encoding out_type=encoding::unknown);
     static witness_address from_witness(const witness_p2wsh& decoded,
-        encoding out_type=encoding::mainnet_p2wpkh);
+        encoding out_type=encoding::unknown);
     static witness_address from_data(const data_chunk& data,
-        encoding out_type=encoding::mainnet_p2wpkh);
+        encoding out_type=encoding::unknown);
     static witness_address from_script(const chain::script& script,
-        encoding out_type=encoding::mainnet_p2wpkh);
+        encoding out_type=encoding::unknown);
     static witness_address from_private(const ec_private& secret,
-        encoding out_type=encoding::mainnet_p2wpkh);
+        encoding out_type=encoding::unknown);
     static witness_address from_public(const ec_public& point,
-        encoding out_type=encoding::mainnet_p2wpkh);
+        encoding out_type=encoding::unknown);
 
     encoding encoding_;
     uint8_t witness_version_;

--- a/include/bitcoin/system/wallet/witness_address.hpp
+++ b/include/bitcoin/system/wallet/witness_address.hpp
@@ -33,8 +33,8 @@ class BC_API witness_address
   public:
     enum class address_format: uint8_t
     {
-        p2wpkh,
-        p2wsh
+        witness_pubkey_hash,
+        witness_script_hash
     };
 
     static const std::string mainnet_prefix;
@@ -48,27 +48,27 @@ class BC_API witness_address
     witness_address(witness_address&& other);
     witness_address(const witness_address& other);
     witness_address(const std::string& address,
-        address_format format=address_format::p2wpkh);
+        address_format format=address_format::witness_pubkey_hash);
     witness_address(short_hash&& hash,
-        address_format format=address_format::p2wpkh,
+        address_format format=address_format::witness_pubkey_hash,
         uint8_t witness_version=0, const std::string& prefix=mainnet_prefix);
     witness_address(const short_hash& hash,
-        address_format format=address_format::p2wpkh,
+        address_format format=address_format::witness_pubkey_hash,
         uint8_t witness_version=0, const std::string& prefix=mainnet_prefix);
     witness_address(hash_digest&& hash,
-        address_format format=address_format::p2wpkh,
+        address_format format=address_format::witness_pubkey_hash,
         uint8_t witness_version=0, const std::string& prefix=mainnet_prefix);
     witness_address(const hash_digest& hash,
-        address_format format=address_format::p2wpkh,
+        address_format format=address_format::witness_pubkey_hash,
         uint8_t witness_version=0, const std::string& prefix=mainnet_prefix);
     witness_address(const chain::script& script,
-        address_format format=address_format::p2wpkh,
+        address_format format=address_format::witness_pubkey_hash,
         const std::string& prefix=mainnet_prefix);
     witness_address(const ec_private& secret,
-        address_format format=address_format::p2wpkh,
+        address_format format=address_format::witness_pubkey_hash,
         const std::string& prefix=mainnet_prefix);
     witness_address(const ec_public& point,
-        address_format format=address_format::p2wpkh,
+        address_format format=address_format::witness_pubkey_hash,
         const std::string& prefix=mainnet_prefix);
 
     /// Operators.
@@ -76,6 +76,8 @@ class BC_API witness_address
     bool operator==(const witness_address& other) const;
     bool operator!=(const witness_address& other) const;
     witness_address& operator=(const witness_address& other);
+    friend std::istream& operator>>(std::istream& in,
+        witness_address& to);
     friend std::ostream& operator<<(std::ostream& out,
         const witness_address& of);
 
@@ -101,16 +103,16 @@ private:
 
     /// Factories.
     static witness_address from_string(const std::string& address,
-        address_format format=address_format::p2wpkh,
+        address_format format=address_format::witness_pubkey_hash,
         const std::string& prefix=mainnet_prefix);
     static witness_address from_script(const chain::script& script,
-        address_format format=address_format::p2wpkh,
+        address_format format=address_format::witness_pubkey_hash,
         const std::string& prefix=mainnet_prefix);
     static witness_address from_private(const ec_private& secret,
-        address_format format=address_format::p2wpkh,
+        address_format format=address_format::witness_pubkey_hash,
         const std::string& prefix=mainnet_prefix);
     static witness_address from_public(const ec_public& point,
-        address_format format=address_format::p2wpkh,
+        address_format format=address_format::witness_pubkey_hash,
         const std::string& prefix=mainnet_prefix);
 
     std::string prefix_;

--- a/include/bitcoin/system/wallet/witness_address.hpp
+++ b/include/bitcoin/system/wallet/witness_address.hpp
@@ -67,9 +67,9 @@ class BC_API witness_address
 
     /// Create base58 witness programs using provided information.
     static void to_witness(witness_p2wsh& out, uint8_t version,
-        uint8_t witness_version, hash_digest hash);
+        uint8_t witness_version, const hash_digest& hash);
     static void to_witness(witness_p2wpkh& out, uint8_t version,
-        uint8_t witness_version, short_hash hash);
+        uint8_t witness_version, const short_hash& hash);
 
     /// Constructors.
     witness_address();

--- a/include/bitcoin/system/wallet/witness_address.hpp
+++ b/include/bitcoin/system/wallet/witness_address.hpp
@@ -61,10 +61,6 @@ public:
     typedef std::vector<witness_address> list;
     typedef std::shared_ptr<witness_address> ptr;
 
-    /// Public for unit testing.
-    static data_chunk convert_bits(uint32_t from_bits, uint32_t to_bits,
-        bool pad, const data_chunk& in, size_t in_offset);
-
     /// Create base58 witness programs using provided information.
     static void to_witness(witness_p2wpkh& out, encoding out_type,
         uint8_t witness_version, short_hash hash);
@@ -119,6 +115,11 @@ public:
     uint8_t witness_version() const;
     const hash_digest& witness_hash() const;
     chain::script output_script() const;
+
+protected:
+    /// Protected for unit testing.
+    static data_chunk convert_bits(uint32_t from_bits, uint32_t to_bits,
+        bool pad, const data_chunk& in, size_t in_offset);
 
 private:
     /// Validators.

--- a/include/bitcoin/system/wallet/witness_address.hpp
+++ b/include/bitcoin/system/wallet/witness_address.hpp
@@ -41,10 +41,10 @@ public:
     {
         // BIP 142 p2wpkh and p2wsh address versions.
         // https://github.com/bitcoin/bips/blob/master/bip-0142.mediawiki#specification
-        mainnet_p2sh_p2wpkh = 0x06,
-        testnet_p2sh_p2wpkh = 0x03,
-        mainnet_p2sh_p2wsh = 0x0a,
-        testnet_p2sh_p2wsh = 0x28,
+        mainnet_base58_p2wpkh = 0x06,
+        testnet_base58_p2wpkh = 0x03,
+        mainnet_base58_p2wsh = 0x0a,
+        testnet_base58_p2wsh = 0x28,
 
         // These encoding values are not from a specification.
         mainnet_p2wpkh,
@@ -54,12 +54,6 @@ public:
 
         unknown
     };
-
-    static const uint8_t mainnet_p2sh_p2wpkh;
-    static const uint8_t mainnet_p2sh_p2wsh;
-
-    static const uint8_t testnet_p2sh_p2wpkh;
-    static const uint8_t testnet_p2sh_p2wsh;
 
     static const std::string mainnet_prefix;
     static const std::string testnet_prefix;
@@ -71,7 +65,7 @@ public:
     static data_chunk convert_bits(uint32_t from_bits, uint32_t to_bits,
         bool pad, const data_chunk& in, size_t in_offset);
 
-    /// Create p2sh witness programs using provided information.
+    /// Create base58 witness programs using provided information.
     static void to_witness(witness_p2wpkh& out, encoding out_type,
         uint8_t witness_version, short_hash hash);
     static void to_witness(witness_p2wsh& out, encoding out_type,

--- a/include/bitcoin/system/wallet/witness_address.hpp
+++ b/include/bitcoin/system/wallet/witness_address.hpp
@@ -26,79 +26,49 @@ namespace libbitcoin {
 namespace system {
 namespace wallet {
 
-static BC_CONSTEXPR uint8_t padding = 0x00;
-static BC_CONSTEXPR size_t witness_prefix_size = 3u;
-static BC_CONSTEXPR size_t witness_p2wsh_size = witness_prefix_size +
-    hash_size + checksum_size;
-static BC_CONSTEXPR size_t witness_p2wpkh_size = witness_prefix_size +
-    short_hash_size + checksum_size;
-
-typedef byte_array<witness_p2wsh_size> witness_p2wsh;
-typedef byte_array<witness_p2wpkh_size> witness_p2wpkh;
-
 /// A class for working with standard witness payment addresses.
 class BC_API witness_address
   : public payment_address
 {
   public:
+    enum class address_format: uint8_t
+    {
+        p2wpkh,
+        p2wsh
+    };
+
     static const std::string mainnet_prefix;
     static const std::string testnet_prefix;
 
-    static const std::string mainnet_p2wpkh;
-    static const std::string testnet_p2wpkh;
-
-    static const std::string mainnet_p2wsh;
-    static const std::string testnet_p2wsh;
-
-    static const uint8_t mainnet_bech32_p2wpkh;
-    static const uint8_t mainnet_bech32_p2wsh;
-
-    static const uint8_t testnet_bech32_p2wpkh;
-    static const uint8_t testnet_bech32_p2wsh;
-
-    static const uint8_t mainnet_base58_p2wpkh;
-    static const uint8_t mainnet_base58_p2wsh;
-
-    static const uint8_t testnet_base58_p2wpkh;
-    static const uint8_t testnet_base58_p2wsh;
-
     typedef std::vector<witness_address> list;
     typedef std::shared_ptr<witness_address> ptr;
-
-    /// Create base58 witness programs using provided information.
-    static void to_witness(witness_p2wsh& out, uint8_t version,
-        uint8_t witness_version, const hash_digest& hash);
-    static void to_witness(witness_p2wpkh& out, uint8_t version,
-        uint8_t witness_version, const short_hash& hash);
 
     /// Constructors.
     witness_address();
     witness_address(witness_address&& other);
     witness_address(const witness_address& other);
-    witness_address(const witness_p2wpkh& decoded,
-        uint8_t version=mainnet_bech32_p2wpkh);
-    witness_address(const witness_p2wsh& decoded,
-        uint8_t version=mainnet_bech32_p2wpkh);
     witness_address(const std::string& address,
-        uint8_t version=mainnet_bech32_p2wpkh);
-    witness_address(short_hash&& hash, uint8_t version=mainnet_bech32_p2wpkh,
+        address_format format=address_format::p2wpkh);
+    witness_address(short_hash&& hash,
+        address_format format=address_format::p2wpkh,
         uint8_t witness_version=0, const std::string& prefix=mainnet_prefix);
     witness_address(const short_hash& hash,
-        uint8_t version=mainnet_bech32_p2wpkh, uint8_t witness_version=0,
-        const std::string& prefix=mainnet_prefix);
-    witness_address(hash_digest&& hash, uint8_t version=mainnet_bech32_p2wpkh,
+        address_format format=address_format::p2wpkh,
+        uint8_t witness_version=0, const std::string& prefix=mainnet_prefix);
+    witness_address(hash_digest&& hash,
+        address_format format=address_format::p2wpkh,
         uint8_t witness_version=0, const std::string& prefix=mainnet_prefix);
     witness_address(const hash_digest& hash,
-        uint8_t version=mainnet_bech32_p2wpkh, uint8_t witness_version=0,
-        const std::string& prefix=mainnet_prefix);
+        address_format format=address_format::p2wpkh,
+        uint8_t witness_version=0, const std::string& prefix=mainnet_prefix);
     witness_address(const chain::script& script,
-        uint8_t version=mainnet_bech32_p2wpkh,
+        address_format format=address_format::p2wpkh,
         const std::string& prefix=mainnet_prefix);
     witness_address(const ec_private& secret,
-        uint8_t version=mainnet_bech32_p2wpkh,
+        address_format format=address_format::p2wpkh,
         const std::string& prefix=mainnet_prefix);
     witness_address(const ec_public& point,
-        uint8_t version=mainnet_bech32_p2wpkh,
+        address_format format=address_format::p2wpkh,
         const std::string& prefix=mainnet_prefix);
 
     /// Operators.
@@ -113,7 +83,6 @@ class BC_API witness_address
     operator bool() const;
 
     /// Serializer.
-    std::string bech32() const;
     std::string encoded() const;
 
     /// Accessors.
@@ -132,23 +101,20 @@ private:
 
     /// Factories.
     static witness_address from_string(const std::string& address,
-        uint8_t version=mainnet_bech32_p2wpkh,
+        address_format format=address_format::p2wpkh,
         const std::string& prefix=mainnet_prefix);
-    static witness_address from_witness(const witness_p2wpkh& decoded,
-        uint8_t version=mainnet_base58_p2wpkh);
-    static witness_address from_witness(const witness_p2wsh& decoded,
-        uint8_t version=mainnet_base58_p2wsh);
     static witness_address from_script(const chain::script& script,
-        uint8_t version=mainnet_bech32_p2wpkh,
+        address_format format=address_format::p2wpkh,
         const std::string& prefix=mainnet_prefix);
     static witness_address from_private(const ec_private& secret,
-        uint8_t version=mainnet_bech32_p2wpkh,
+        address_format format=address_format::p2wpkh,
         const std::string& prefix=mainnet_prefix);
     static witness_address from_public(const ec_public& point,
-        uint8_t version=mainnet_bech32_p2wpkh,
+        address_format format=address_format::p2wpkh,
         const std::string& prefix=mainnet_prefix);
 
     std::string prefix_;
+    address_format format_;
     uint8_t witness_version_;
     hash_digest witness_hash_;
 };

--- a/include/bitcoin/system/wallet/witness_address.hpp
+++ b/include/bitcoin/system/wallet/witness_address.hpp
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2011-2019 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBBITCOIN_SYSTEM_WALLET_WITNESS_ADDRESS_HPP
+#define LIBBITCOIN_SYSTEM_WALLET_WITNESS_ADDRESS_HPP
+
+#include <bitcoin/system/math/hash.hpp>
+#include <bitcoin/system/wallet/payment_address.hpp>
+
+namespace libbitcoin {
+namespace system {
+namespace wallet {
+
+static BC_CONSTEXPR uint8_t padding = 0x00;
+static BC_CONSTEXPR size_t witness_p2wpkh_size = 3u + short_hash_size + checksum_size;
+static BC_CONSTEXPR size_t witness_p2wsh_size = 3u + hash_size + checksum_size;
+typedef byte_array<witness_p2wpkh_size> witness_p2wpkh;
+typedef byte_array<witness_p2wsh_size> witness_p2wsh;
+
+/// A class for working with standard witness payment addresses.
+class BC_API witness_address
+  : public payment_address
+{
+public:
+    enum class encoding: uint8_t
+    {
+        // BIP 142 p2wpkh and p2wsh address versions.
+        // https://github.com/bitcoin/bips/blob/master/bip-0142.mediawiki#specification
+        mainnet_p2sh_p2wpkh = 0x06,
+        testnet_p2sh_p2wpkh = 0x03,
+        mainnet_p2sh_p2wsh = 0x0a,
+        testnet_p2sh_p2wsh = 0x28,
+
+        // These encoding values are not from a specification.
+        mainnet_p2wpkh,
+        mainnet_p2wsh,
+        testnet_p2wpkh,
+        testnet_p2wsh,
+     };
+
+    static const uint8_t mainnet_p2sh_p2wpkh;
+    static const uint8_t mainnet_p2sh_p2wsh;
+
+    static const uint8_t testnet_p2sh_p2wpkh;
+    static const uint8_t testnet_p2sh_p2wsh;
+
+    static const std::string mainnet_prefix;
+    static const std::string testnet_prefix;
+
+    typedef std::vector<witness_address> list;
+    typedef std::shared_ptr<witness_address> ptr;
+
+    /// Public for unit testing.
+    static data_chunk convert_bits(uint32_t from_bits, uint32_t to_bits,
+        bool pad, const data_chunk& in, size_t in_offset);
+
+    /// Create p2sh witness programs using provided information.
+    static void to_witness(witness_p2wpkh& out, encoding out_type,
+        uint8_t witness_version, short_hash hash);
+    static void to_witness(witness_p2wsh& out, encoding out_type,
+        uint8_t witness_version, hash_digest hash);
+
+    /// Constructors.
+    witness_address();
+    witness_address(witness_address&& other);
+    witness_address(const witness_address& other);
+    witness_address(const witness_p2wpkh& decoded,
+        encoding out_type=encoding::mainnet_p2wpkh);
+    witness_address(const witness_p2wsh& decoded,
+        encoding out_type=encoding::mainnet_p2wpkh);
+    witness_address(const data_chunk& data,
+        encoding out_type=encoding::mainnet_p2wpkh);
+    witness_address(const std::string& address,
+        encoding out_type=encoding::mainnet_p2wpkh);
+    witness_address(short_hash&& hash,
+        encoding out_type=encoding::mainnet_p2wpkh,
+        uint8_t witness_version=0);
+    witness_address(const short_hash& hash,
+        encoding out_type=encoding::mainnet_p2wpkh,
+        uint8_t witness_version=0);
+    witness_address(hash_digest&& hash,
+        encoding out_type=encoding::mainnet_p2wpkh,
+        uint8_t witness_version=0);
+    witness_address(const hash_digest& hash,
+        encoding out_type=encoding::mainnet_p2wpkh,
+        uint8_t witness_version=0);
+    witness_address(const chain::script& script,
+        encoding out_type=encoding::mainnet_p2wpkh);
+    witness_address(const ec_private& secret,
+        encoding out_type=encoding::mainnet_p2wpkh);
+    witness_address(const ec_public& point,
+        encoding out_type=encoding::mainnet_p2wpkh);
+
+    /// Operators.
+    bool operator<(const witness_address& other) const;
+    bool operator==(const witness_address& other) const;
+    bool operator!=(const witness_address& other) const;
+    witness_address& operator=(const witness_address& other);
+    friend std::istream& operator>>(std::istream& in, witness_address& to);
+    friend std::ostream& operator<<(std::ostream& out,
+        const witness_address& of);
+
+    /// Cast operators.
+    operator bool() const;
+
+    /// Serializer.
+    std::string bech32(const std::string& prefix=mainnet_prefix) const;
+    std::string encoded() const;
+
+    /// Accessors.
+    uint8_t witness_version() const;
+    const hash_digest& witness_hash() const;
+    chain::script output_script() const;
+
+private:
+    /// Validators.
+    static bool is_address(data_slice decoded);
+
+    /// Factories.
+    static witness_address from_string(const std::string& address,
+        encoding out_type=encoding::mainnet_p2wpkh);
+    static witness_address from_witness(const witness_p2wpkh& decoded,
+        encoding out_type=encoding::mainnet_p2wpkh);
+    static witness_address from_witness(const witness_p2wsh& decoded,
+        encoding out_type=encoding::mainnet_p2wpkh);
+    static witness_address from_data(const data_chunk& data,
+        encoding out_type=encoding::mainnet_p2wpkh);
+    static witness_address from_script(const chain::script& script,
+        encoding out_type=encoding::mainnet_p2wpkh);
+    static witness_address from_private(const ec_private& secret,
+        encoding out_type=encoding::mainnet_p2wpkh);
+    static witness_address from_public(const ec_public& point,
+        encoding out_type=encoding::mainnet_p2wpkh);
+
+    encoding encoding_;
+    uint8_t witness_version_;
+    hash_digest witness_hash_;
+};
+
+} // namespace wallet
+} // namespace system
+} // namespace libbitcoin
+
+// Allow witness_address to be in indexed in std::*map classes.
+namespace std
+{
+template <>
+struct hash<bc::system::wallet::witness_address>
+{
+    size_t operator()(const bc::system::wallet::witness_address& address) const
+    {
+        return address.witness_hash() == bc::system::null_hash ?
+            std::hash<bc::system::short_hash>()(address.hash()) :
+            std::hash<bc::system::hash_digest>()(address.witness_hash());
+    }
+};
+
+} // namespace std
+
+#endif

--- a/src/chain/script.cpp
+++ b/src/chain/script.cpp
@@ -1171,6 +1171,24 @@ operation::list script::to_pay_multisig_pattern(uint8_t signatures,
     return ops;
 }
 
+operation::list script::to_pay_witness_key_hash_pattern(const short_hash& hash)
+{
+    return operation::list
+    {
+        { opcode::push_size_0 },
+        { to_chunk(hash) },
+    };
+}
+
+operation::list script::to_pay_witness_script_hash_pattern(const hash_digest& hash)
+{
+    return operation::list
+    {
+        { opcode::push_size_0 },
+        { to_chunk(hash) }
+    };
+}
+
 // Utilities (non-static).
 //-----------------------------------------------------------------------------
 

--- a/src/chain/script.cpp
+++ b/src/chain/script.cpp
@@ -367,6 +367,12 @@ std::string script::to_string(uint32_t active_forks) const
     return text.str();
 }
 
+hash_digest script::to_payments_key() const
+{
+    return sha256_hash(to_data(false));
+}
+
+
 // Iteration.
 //-----------------------------------------------------------------------------
 // These are syntactic sugar that allow the caller to iterate ops directly.

--- a/src/chain/script.cpp
+++ b/src/chain/script.cpp
@@ -1179,7 +1179,7 @@ operation::list script::to_pay_multisig_pattern(uint8_t signatures,
 
 operation::list script::to_pay_witness_key_hash_pattern(const short_hash& hash)
 {
-    return operation::list
+    return
     {
         { opcode::push_size_0 },
         { to_chunk(hash) },
@@ -1188,7 +1188,7 @@ operation::list script::to_pay_witness_key_hash_pattern(const short_hash& hash)
 
 operation::list script::to_pay_witness_script_hash_pattern(const hash_digest& hash)
 {
-    return operation::list
+    return
     {
         { opcode::push_size_0 },
         { to_chunk(hash) }

--- a/src/formats/base_32.cpp
+++ b/src/formats/base_32.cpp
@@ -93,11 +93,13 @@ uint32_t polymod(const data_chunk& values)
         0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3
     };
 
+    const auto result_mask = 0x1ffffff;
+
     uint32_t result = 1;
     for (const auto value: values)
     {
         const auto shift = (result >> 25);
-        result = (result & 0x1ffffff) << bit_group_size ^ value;
+        result = (result & result_mask) << bit_group_size ^ value;
 
         for (size_t index = 0; index < bit_group_size; ++index)
             result ^= (((shift >> index) & 1) != 0 ? magic_numbers[index] : 0);

--- a/src/formats/base_32.cpp
+++ b/src/formats/base_32.cpp
@@ -22,7 +22,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
-#include <string>
+#include <sstream>
 #include <bitcoin/system/utility/data.hpp>
 
 namespace libbitcoin {
@@ -122,8 +122,8 @@ data_chunk checksum(const base32& value)
     data_chunk checksum(checksum_size);
     const auto modified = polymod(expanded) ^ 1;
 
-    for (size_t index = 0; index < checksum.size(); ++index)
-        checksum[index] = (modified >> (5 * (5 - index))) & 31;
+    for (size_t index = 0; index < checksum_size; ++index)
+        checksum[index] = (modified >> 5 * (5 - index)) & 31;
 
     return checksum;
 }
@@ -213,23 +213,20 @@ bool verify(const base32& value)
 // to produce uppercase encodings, though the values may be simply mapped.
 std::string encode_base32(const base32& unencoded)
 {
-    std::string encoded;
-    encoded.reserve(unencoded.prefix.size() + sizeof(separator) +
-        unencoded.payload.size() + checksum_size);
+    std::stringstream encoded;
 
     // Copy the prefix and add the separator.
-    encoded = unencoded.prefix;
-    encoded += separator;
+    encoded << unencoded.prefix << separator;
 
     // Encode and add the payload.
     for (const auto value: unencoded.payload)
-        encoded += encode_table[value];
+        encoded << encode_table[value];
 
     // Compute, encode and add the checksum.
     for (const auto value: checksum(unencoded))
-        encoded += encode_table[value];
+        encoded << encode_table[value];
 
-    return encoded;
+    return encoded.str();
 }
 
 bool decode_base32(base32& out, const std::string& in)

--- a/src/formats/base_32.cpp
+++ b/src/formats/base_32.cpp
@@ -92,7 +92,7 @@ uint32_t polymod(const data_chunk& values)
     // simple integers. Generally 30-bit integers are used, where each
     // bit corresponds to one coefficient of the polynomial.
     //
-    // https://bitcoin.stackexchange.com/questions/74573/how-is-bech32-based-on-bch-codes
+    // bitcoin.stackexchange.com/questions/74573/how-is-bech32-based-on-bch-codes
     static const uint32_t bech32_generator_polynomials[] =
     {
         0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3

--- a/src/wallet/witness_address.cpp
+++ b/src/wallet/witness_address.cpp
@@ -1,0 +1,544 @@
+/**
+ * Copyright (c) 2011-2019 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <bitcoin/system/wallet/witness_address.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <boost/program_options.hpp>
+#include <bitcoin/system/formats/base_32.hpp>
+#include <bitcoin/system/formats/base_58.hpp>
+#include <bitcoin/system/math/checksum.hpp>
+#include <bitcoin/system/math/elliptic_curve.hpp>
+#include <bitcoin/system/math/hash.hpp>
+#include <bitcoin/system/wallet/ec_private.hpp>
+#include <bitcoin/system/wallet/ec_public.hpp>
+
+namespace libbitcoin {
+namespace system {
+namespace wallet {
+
+using namespace bc::system::machine;
+
+// BIP 173 prefix constants.
+// https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#segwit-address-format
+const std::string witness_address::mainnet_prefix = "bc";
+const std::string witness_address::testnet_prefix = "tb";
+
+
+witness_address::witness_address()
+  : payment_address(),
+    encoding_(encoding::mainnet_p2wpkh),
+    witness_version_(0),
+    witness_hash_(null_hash)
+{
+}
+
+witness_address::witness_address(witness_address&& other)
+  : payment_address(other),
+    encoding_(other.encoding_),
+    witness_version_(other.witness_version_),
+    witness_hash_(std::move(other.witness_hash_))
+{
+}
+
+witness_address::witness_address(const witness_address& other)
+  : payment_address(other),
+    encoding_(other.encoding_),
+    witness_version_(other.witness_version_),
+    witness_hash_(other.witness_hash_)
+{
+}
+
+witness_address::witness_address(const witness_p2wpkh& decoded,
+    encoding out_type)
+  : witness_address(from_witness(decoded, out_type))
+{
+}
+
+witness_address::witness_address(const witness_p2wsh& decoded,
+    encoding out_type)
+  : witness_address(from_witness(decoded, out_type))
+{
+}
+
+witness_address::witness_address(const data_chunk& data, encoding out_type)
+  : witness_address(from_data(data, out_type))
+{
+}
+
+witness_address::witness_address(const std::string& address, encoding out_type)
+  : witness_address(from_string(address, out_type))
+{
+}
+
+witness_address::witness_address(const ec_private& secret, encoding out_type)
+  : witness_address(from_private(secret, out_type))
+{
+}
+
+witness_address::witness_address(const ec_public& point, encoding out_type)
+  : witness_address(from_public(point, out_type))
+{
+}
+
+witness_address::witness_address(const chain::script& script, encoding out_type)
+  : witness_address(from_script(script, out_type))
+{
+}
+
+witness_address::witness_address(short_hash&& hash, encoding out_type,
+    uint8_t witness_version)
+  : payment_address(std::move(hash)),
+    encoding_(out_type),
+    witness_version_(witness_version),
+    witness_hash_(null_hash)
+{
+}
+
+witness_address::witness_address(const short_hash& hash, encoding out_type,
+    uint8_t witness_version)
+  : payment_address(hash),
+    encoding_(out_type),
+    witness_version_(witness_version),
+    witness_hash_(null_hash)
+{
+}
+
+witness_address::witness_address(hash_digest&& hash, encoding out_type,
+    uint8_t witness_version)
+  : payment_address(null_short_hash),
+    encoding_(out_type),
+    witness_version_(witness_version),
+    witness_hash_(std::move(hash))
+{
+}
+
+witness_address::witness_address(const hash_digest& hash, encoding out_type,
+    uint8_t witness_version)
+  : payment_address(null_short_hash),
+    encoding_(out_type),
+    witness_version_(witness_version),
+    witness_hash_(hash)
+{
+}
+
+// Validators.
+// ----------------------------------------------------------------------------
+
+bool witness_address::is_address(data_slice decoded)
+{
+    return ((decoded.size() == witness_p2wpkh_size) ||
+            (decoded.size() == witness_p2wsh_size)) && verify_checksum(decoded);
+}
+
+// Factories.
+// ----------------------------------------------------------------------------
+
+// static
+witness_address witness_address::from_string(const std::string& address,
+    encoding out_type)
+{
+    // Attempt to decode BIP 173 address format.
+    base32 bech32_decoded;
+    if (decode_base32(bech32_decoded, address))
+    {
+        const uint8_t witness_version = bech32_decoded.payload.front();
+
+        // Checks specific to witness version 0.
+        if (witness_version == 0 && (address.size() < 42 || address.size() > 62))
+            return {};
+
+        // Verify witness version is valid (only version 0 is
+        // currently supported).
+        if (witness_version != 0)
+            return {};
+
+        // Verify additional properties (BIP173 decoding).
+        if (address.size() < 14 || address.size() > 74)
+            return {};
+
+        const auto address_mod = address.size() % 8;
+        if (address_mod == 0 || address_mod == 3 || address_mod == 5)
+            return {};
+
+        const auto converted = convert_bits(5, 8, false,
+            bech32_decoded.payload, 1);
+        if (converted.size() < 2 || converted.size() > 40)
+            return {};
+
+        // Reinterpret casting avoids a copy, but should probably be replaced.
+        if (converted.size() == hash_size)
+            return { *reinterpret_cast<const hash_digest*>(&converted[0]),
+                out_type, witness_version };
+        else if (converted.size() == short_hash_size)
+            return { *reinterpret_cast<const short_hash*>(&converted[0]),
+                out_type, witness_version };
+
+        // This is a witness_version 0 of an unsupported length.
+        return {};
+    }
+
+    // Attempt to decode BIP 142 address format.
+    data_chunk decoded;
+    if (!decode_base58(decoded, address) || !is_address(decoded))
+        return {};
+
+    // Reinterpret casting avoids a copy, but should probably be replaced.
+    if (decoded.size() == witness_p2wpkh_size)
+        return { *reinterpret_cast<witness_p2wpkh*>(&decoded[0]), out_type };
+    else if (decoded.size() == witness_p2wsh_size)
+        return { *reinterpret_cast<witness_p2wsh*>(&decoded[0]), out_type };
+
+    // Address is an unrecognized format.
+    return {};
+}
+
+// static
+witness_address witness_address::from_data(const data_chunk& data,
+    encoding out_type)
+{
+    switch(out_type)
+    {
+        case encoding::mainnet_p2wpkh:
+        case encoding::testnet_p2wpkh:
+            return witness_address(ripemd160_hash(sha256_hash(data)), out_type);
+
+        case encoding::mainnet_p2wsh:
+        case encoding::testnet_p2wsh:
+            return witness_address(sha256_hash(data), out_type);
+
+        default:
+            return {};
+    }
+}
+
+// static
+witness_address witness_address::from_witness(const witness_p2wpkh& decoded,
+    encoding out_type)
+{
+    if (!is_address(decoded))
+        return {};
+
+    const short_hash hash = slice<3, short_hash_size + 3>(decoded);
+    return { hash, out_type };
+}
+
+// static
+witness_address witness_address::from_witness(const witness_p2wsh& decoded,
+    encoding out_type)
+{
+    if (!is_address(decoded))
+        return {};
+
+    const hash_digest hash = slice<3, hash_size + 3>(decoded);
+    return { hash, out_type };
+}
+
+// static
+witness_address witness_address::from_private(const ec_private& secret,
+    encoding out_type)
+{
+    if (secret)
+        return { secret.to_public(), out_type };
+
+    return {};
+}
+
+// static
+witness_address witness_address::from_public(const ec_public& point,
+    encoding out_type)
+{
+    if (!point)
+        return {};
+
+    data_chunk data;
+    if (!point.to_data(data))
+        return {};
+
+    if (out_type == encoding::mainnet_p2sh_p2wpkh ||
+        out_type == encoding::testnet_p2sh_p2wpkh ||
+        out_type == encoding::mainnet_p2wpkh ||
+        out_type == encoding::testnet_p2wpkh)
+        return { bitcoin_short_hash(data), out_type };
+
+    return { bitcoin_hash(data), out_type };
+}
+
+// static
+witness_address witness_address::from_script(const chain::script& script,
+    encoding out_type)
+{
+    switch(out_type)
+    {
+        case encoding::mainnet_p2sh_p2wpkh:
+        case encoding::testnet_p2sh_p2wpkh:
+        case encoding::mainnet_p2wpkh:
+        case encoding::testnet_p2wpkh:
+            return witness_address(ripemd160_hash(sha256_hash(
+                script.to_data(false))), out_type);
+
+        case encoding::mainnet_p2sh_p2wsh:
+        case encoding::testnet_p2sh_p2wsh:
+        case encoding::mainnet_p2wsh:
+        case encoding::testnet_p2wsh:
+            return witness_address(sha256_hash(script.to_data(false)),
+                out_type);
+
+        default:
+            return {};
+    }
+}
+
+// Cast operators.
+// ----------------------------------------------------------------------------
+
+witness_address::operator bool() const
+{
+    return valid_;
+}
+
+// Serializer.
+// ----------------------------------------------------------------------------
+
+// Returns the bech32 encoded witness address.
+std::string witness_address::bech32(const std::string& prefix) const
+{
+    base32 bech32;
+    bech32.prefix = prefix;
+    bech32.payload = to_chunk(witness_version_);
+
+    const auto converted = (witness_hash_ == null_hash ?
+        convert_bits(8, 5, true, to_chunk(hash_), 0) :
+        convert_bits(8, 5, true, to_chunk(witness_hash_), 0));
+
+    extend_data(bech32.payload, converted);
+    return encode_base32(bech32);
+}
+
+// Returns the bech32 or base58 encoded witness address, depending on
+// the encoding.
+std::string witness_address::encoded() const
+{
+    switch (encoding_)
+    {
+        case encoding::mainnet_p2sh_p2wpkh:
+        case encoding::testnet_p2sh_p2wpkh:
+        {
+            witness_p2wpkh witness;
+            to_witness(witness, encoding_, witness_version_, hash_);
+            return encode_base58(witness);
+        }
+
+        case encoding::mainnet_p2sh_p2wsh:
+        case encoding::testnet_p2sh_p2wsh:
+        {
+            witness_p2wsh witness;
+            to_witness(witness, encoding_, witness_version_, witness_hash_);
+            return encode_base58(witness);
+        }
+
+        case encoding::mainnet_p2wpkh:
+        case encoding::mainnet_p2wsh:
+            return bech32(mainnet_prefix);
+
+        case encoding::testnet_p2wpkh:
+        case encoding::testnet_p2wsh:
+            return bech32(testnet_prefix);
+
+        default:
+            return {};
+    }
+}
+
+// Accessors.
+// ----------------------------------------------------------------------------
+
+uint8_t witness_address::witness_version() const
+{
+    return witness_version_;
+}
+
+const hash_digest& witness_address::witness_hash() const
+{
+    return witness_hash_;
+}
+
+chain::script witness_address::output_script() const
+{
+    switch (encoding_)
+    {
+        case encoding::mainnet_p2sh_p2wpkh:
+        case encoding::testnet_p2sh_p2wpkh:
+        {
+            const operation::list operations{ opcode(0), operation(to_chunk(hash_)) };
+            const chain::script witness_program(operations);
+            const auto witness_hash = bitcoin_short_hash(witness_program.to_data(false));
+
+            return chain::script::to_pay_script_hash_pattern(witness_hash);
+        }
+
+        case encoding::mainnet_p2sh_p2wsh:
+        case encoding::testnet_p2sh_p2wsh:
+        {
+            const operation::list operations{ opcode(0), operation(to_chunk(witness_hash_)) };
+            const chain::script witness_program(operations);
+            const auto witness_hash = bitcoin_short_hash(witness_program.to_data(false));
+
+            return chain::script::to_pay_script_hash_pattern(witness_hash);
+        }
+
+        case encoding::mainnet_p2wpkh:
+        case encoding::testnet_p2wpkh:
+            return chain::script::to_pay_witness_key_hash_pattern(hash_);
+
+        case encoding::mainnet_p2wsh:
+        case encoding::testnet_p2wsh:
+            return chain::script::to_pay_witness_script_hash_pattern(witness_hash_);
+
+        default:
+            return {};
+    }
+}
+
+// Methods.
+// ----------------------------------------------------------------------------
+
+/// static
+void witness_address::to_witness(witness_p2wpkh& out, encoding out_type,
+    uint8_t witness_version, short_hash hash)
+{
+    build_array(out,
+    {
+        to_array(static_cast<uint8_t>(out_type)),
+        to_array(witness_version),
+        to_array(padding),
+        hash
+    });
+
+    insert_checksum(out);
+}
+
+/// static
+void witness_address::to_witness(witness_p2wsh& out, encoding out_type,
+    uint8_t witness_version, hash_digest hash)
+{
+    build_array(out,
+    {
+        to_array(static_cast<uint8_t>(out_type)),
+        to_array(witness_version),
+        to_array(padding),
+        hash
+    });
+
+    insert_checksum(out);
+}
+
+// Operators.
+// ----------------------------------------------------------------------------
+
+witness_address& witness_address::operator=(const witness_address& other)
+{
+    valid_ = other.valid_;
+    encoding_ = other.encoding_;
+    witness_version_ = other.witness_version_;
+    hash_ = other.hash_;
+    witness_hash_ = other.witness_hash_;
+    return *this;
+}
+
+bool witness_address::operator<(const witness_address& other) const
+{
+    return encoded() < other.encoded();
+}
+
+bool witness_address::operator==(const witness_address& other) const
+{
+    return valid_ == other.valid_ && encoding_ == other.encoding_ &&
+        witness_version_ == other.witness_version_ &&
+        hash_ == other.hash_ && witness_hash_ == other.witness_hash_;
+}
+
+bool witness_address::operator!=(const witness_address& other) const
+{
+    return !(*this == other);
+}
+
+std::istream& operator>>(std::istream& in, witness_address& to)
+{
+    std::string value;
+    in >> value;
+    to = witness_address(value);
+
+    if (!to)
+    {
+        using namespace boost::program_options;
+        BOOST_THROW_EXCEPTION(invalid_option_value(value));
+    }
+
+    return in;
+}
+
+std::ostream& operator<<(std::ostream& out, const witness_address& of)
+{
+    out << of.encoded();
+    return out;
+}
+
+// static
+data_chunk witness_address::convert_bits(uint32_t from_bits, uint32_t to_bits,
+    bool pad, const data_chunk& in, size_t in_offset)
+{
+    const uint32_t maximum = (1 << to_bits) - 1;
+    const uint32_t maximum_accumulator = (1 << (from_bits + to_bits - 1)) - 1;
+
+    size_t offset = 0;
+    uint32_t bit_count = 0;
+    uint32_t accumulator = 0;
+
+    data_chunk out;
+    for (const auto value: in)
+    {
+        if (offset++ < in_offset)
+            continue;
+
+        accumulator = ((accumulator << from_bits) | value) &
+            maximum_accumulator;
+        bit_count += from_bits;
+
+        while (bit_count >= to_bits)
+        {
+            bit_count -= to_bits;
+            out.push_back((accumulator >> bit_count) & maximum);
+        }
+    }
+
+    if (pad && bit_count > 0)
+        out.push_back((accumulator << (to_bits - bit_count)) & maximum);
+    else if (!pad && (bit_count >= from_bits ||
+        ((accumulator << (to_bits - bit_count)) & maximum)))
+        return {};
+
+    return out;
+}
+
+} // namespace wallet
+} // namespace system
+} // namespace libbitcoin

--- a/test/wallet/witness_address.cpp
+++ b/test/wallet/witness_address.cpp
@@ -174,6 +174,17 @@ BOOST_AUTO_TEST_CASE(witness_address__witness_vectors__valid_expected)
     }
 }
 
+struct witness_address_accessor
+  : public witness_address
+{
+    data_chunk convert_bits(uint32_t from_bits, uint32_t to_bits,
+        bool pad, const data_chunk& in, size_t in_offset)
+    {
+        return witness_address::convert_bits(
+            from_bits, to_bits, pad, in, in_offset);
+    }
+};
+
 BOOST_AUTO_TEST_CASE(base32__witness_address_vectors__valid_expected)
 {
     for (const auto& test: witness_address_tests)
@@ -185,7 +196,8 @@ BOOST_AUTO_TEST_CASE(base32__witness_address_vectors__valid_expected)
         if (witness_version != 0)
             witness_version += 0x50;
 
-        const auto witness_program = witness_address::convert_bits(5, 8, false,
+        witness_address_accessor converter;
+        const auto witness_program = converter.convert_bits(5, 8, false,
             decoded.payload, 1);
         BOOST_REQUIRE(witness_program.size() > 1 &&
                       witness_program.size() < 41);

--- a/test/wallet/witness_address.cpp
+++ b/test/wallet/witness_address.cpp
@@ -85,7 +85,7 @@ test_address_list witness_address_tests =
     { "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy", "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433" }
 };
 
-BOOST_AUTO_TEST_CASE(witness_address__construct__public_to_p2wpkh__valid_expected)
+BOOST_AUTO_TEST_CASE(witness_address__construct__to_p2wpkh__valid_expected)
 {
     const witness_address address(ec_public(BIP142_PUBLIC_KEY), witness_address::encoding::mainnet_p2sh_p2wpkh);
     BOOST_REQUIRE(address);
@@ -99,21 +99,21 @@ BOOST_AUTO_TEST_CASE(witness_address__construct__from_p2sh_p2wpkh_string__valid_
     BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH);
 }
 
-BOOST_AUTO_TEST_CASE(witness_address__construct__public_testnet_to_p2wpkh__valid_expected)
+BOOST_AUTO_TEST_CASE(witness_address__construct__testnet_to_p2wpkh__valid_expected)
 {
     const witness_address address(ec_public(BIP142_PUBLIC_KEY), witness_address::encoding::testnet_p2sh_p2wpkh);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH_TESTNET);
 }
 
-BOOST_AUTO_TEST_CASE(witness_address__construct__public_testnet_to_p2wpkh_string__valid_expected)
+BOOST_AUTO_TEST_CASE(witness_address__construct__testnet_to_p2wpkh_string__valid_expected)
 {
     const witness_address address(std::string(ADDRESS_P2WPKH_TESTNET), witness_address::encoding::testnet_p2sh_p2wpkh);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH_TESTNET);
 }
 
-BOOST_AUTO_TEST_CASE(witness_address__construct__public_mainnet_to_p2wsh__valid_expected)
+BOOST_AUTO_TEST_CASE(witness_address__construct__mainnet_to_p2wsh__valid_expected)
 {
     chain::script script;
     script.from_string(MAINNET_P2WSH_SCRIPT);
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(witness_address__construct__public_mainnet_to_p2wsh__valid_
     BOOST_REQUIRE_EQUAL(address.encoded(), MAINNET_P2WSH_ADDRESS);
 }
 
-BOOST_AUTO_TEST_CASE(witness_address__construct__public_testnet_to_p2wsh__valid_expected)
+BOOST_AUTO_TEST_CASE(witness_address__construct__testnet_to_p2wsh__valid_expected)
 {
     chain::script script;
     script.from_string(TESTNET_P2WSH_SCRIPT);

--- a/test/wallet/witness_address.cpp
+++ b/test/wallet/witness_address.cpp
@@ -26,15 +26,15 @@ using namespace bc::system::wallet;
 BOOST_AUTO_TEST_SUITE(witness_address_tests)
 
 // BIP 173 test constants.
-#define MAINNET_P2WPKH_ADDRESS "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
-#define TESTNET_P2WPKH_ADDRESS "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
-#define TESTNET_P2WPKH_ADDRESS2 "tb1qr47dd36u96r0fjle36hdygdnp0v6pwfgqe6jxg"
+#define MAINNET_WITNESS_PUBKEY_HASH_ADDRESS "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+#define TESTNET_WITNESS_PUBKEY_HASH_ADDRESS "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+#define TESTNET_WITNESS_PUBKEY_HASH_ADDRESS2 "tb1qr47dd36u96r0fjle36hdygdnp0v6pwfgqe6jxg"
 
-#define MAINNET_P2WSH_ADDRESS "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"
-#define MAINNET_P2WSH_SCRIPT "[0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798] checksig"
+#define MAINNET_WITNESS_SCRIPT_HASH_ADDRESS "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"
+#define MAINNET_WITNESS_SCRIPT_HASH_SCRIPT "[0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798] checksig"
 
-#define TESTNET_P2WSH_ADDRESS "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7"
-#define TESTNET_P2WSH_SCRIPT "[0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798] checksig"
+#define TESTNET_WITNESS_SCRIPT_HASH_ADDRESS "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7"
+#define TESTNET_WITNESS_SCRIPT_HASH_SCRIPT "[0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798] checksig"
 
 // BIP 173 witness address vectors
 // https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#test-vectors
@@ -61,35 +61,35 @@ const test_address_list witness_address_nonzero_version_tests =
     { "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj", "5210751e76e8199196d454941c45d1b3a323" },
 };
 
-BOOST_AUTO_TEST_CASE(witness_address__construct__mainnet_to_p2wsh__valid_expected)
+BOOST_AUTO_TEST_CASE(witness_address__construct__mainnet_to_witness_script_hash__valid_expected)
 {
     chain::script script;
-    script.from_string(MAINNET_P2WSH_SCRIPT);
-    const witness_address address(script, witness_address::address_format::p2wsh, witness_address::mainnet_prefix);
+    script.from_string(MAINNET_WITNESS_SCRIPT_HASH_SCRIPT);
+    const witness_address address(script, witness_address::address_format::witness_script_hash, witness_address::mainnet_prefix);
     BOOST_REQUIRE(address);
-    BOOST_REQUIRE_EQUAL(address.encoded(), MAINNET_P2WSH_ADDRESS);
+    BOOST_REQUIRE_EQUAL(address.encoded(), MAINNET_WITNESS_SCRIPT_HASH_ADDRESS);
 }
 
-BOOST_AUTO_TEST_CASE(witness_address__construct__testnet_to_p2wsh__valid_expected)
+BOOST_AUTO_TEST_CASE(witness_address__construct__testnet_to_witness_script_hash__valid_expected)
 {
     chain::script script;
-    script.from_string(TESTNET_P2WSH_SCRIPT);
-    const witness_address address(script, witness_address::address_format::p2wsh, witness_address::testnet_prefix);
+    script.from_string(TESTNET_WITNESS_SCRIPT_HASH_SCRIPT);
+    const witness_address address(script, witness_address::address_format::witness_script_hash, witness_address::testnet_prefix);
     BOOST_REQUIRE(address);
-    BOOST_REQUIRE_EQUAL(address.encoded(), TESTNET_P2WSH_ADDRESS);
+    BOOST_REQUIRE_EQUAL(address.encoded(), TESTNET_WITNESS_SCRIPT_HASH_ADDRESS);
 }
 
-BOOST_AUTO_TEST_CASE(witness_address__construct__ec_public_to_testnet_p2wpkh__valid_expected)
+BOOST_AUTO_TEST_CASE(witness_address__construct__ec_public_to_testnet_witness_pubkey_hash__valid_expected)
 {
     // Based on witness data from:
     // https://www.blockchain.com/btctest/tx/d869f854e1f8788bcff294cc83b280942a8c728de71eb709a2c29d10bfe21b7c
 
     // Create the same witness address from ec_public.
     const std::string test_public_key = "038262a6c6cec93c2d3ecd6c6072efea86d02ff8e3328bbd0242b20af3425990ac";
-    const witness_address address(ec_public(test_public_key), witness_address::address_format::p2wpkh, witness_address::testnet_prefix);
+    const witness_address address(ec_public(test_public_key), witness_address::address_format::witness_pubkey_hash, witness_address::testnet_prefix);
 
     BOOST_REQUIRE(address);
-    BOOST_REQUIRE_EQUAL(address.encoded(), TESTNET_P2WPKH_ADDRESS2);
+    BOOST_REQUIRE_EQUAL(address.encoded(), TESTNET_WITNESS_PUBKEY_HASH_ADDRESS2);
 }
 
 struct witness_address_accessor
@@ -119,13 +119,10 @@ BOOST_AUTO_TEST_CASE(base32__witness_address_zero_version_tests__valid_expected)
         BOOST_REQUIRE(witness_version == 0);
 
         witness_address_accessor converter;
-        const auto witness_program = converter.convert_bits(
-            bech32_contracted_bit_size, bech32_expanded_bit_size, false,
-            decoded.payload, 1);
-
+        const auto witness_program = converter.convert_bits(bech32_contracted_bit_size, bech32_expanded_bit_size, false, decoded.payload, 1);
         const auto witness_program_size = static_cast<uint8_t>(witness_program.size());
-        BOOST_REQUIRE(witness_program_size > witness_v0_program_minimum_limit &&
-                      witness_program_size < witness_v0_program_maximum_limit);
+        BOOST_REQUIRE(witness_program_size > witness_v0_program_minimum_limit);
+        BOOST_REQUIRE(witness_program_size < witness_v0_program_maximum_limit);
 
         const auto result = build_chunk(
         {
@@ -142,7 +139,7 @@ BOOST_AUTO_TEST_CASE(base32__witness_address_nonzero_version_tests__valid_expect
 {
     // This op_version gap is used to normalize the value difference
     // between the defined OP_0 opcode (value 0) and the OP_1 opcode
-    // (value 0x51)
+    // (value 0x51).
     const auto op_version_gap = 0x50;
     const auto witness_v0_program_minimum_limit = 1;
     const auto witness_v0_program_maximum_limit = 41;
@@ -158,13 +155,10 @@ BOOST_AUTO_TEST_CASE(base32__witness_address_nonzero_version_tests__valid_expect
         witness_version += op_version_gap;
 
         witness_address_accessor converter;
-        const auto witness_program = converter.convert_bits(
-            bech32_contracted_bit_size, bech32_expanded_bit_size, false,
-            decoded.payload, 1);
-
+        const auto witness_program = converter.convert_bits(bech32_contracted_bit_size, bech32_expanded_bit_size, false, decoded.payload, 1);
         const auto witness_program_size = static_cast<uint8_t>(witness_program.size());
-        BOOST_REQUIRE(witness_program_size > witness_v0_program_minimum_limit &&
-                      witness_program_size < witness_v0_program_maximum_limit);
+        BOOST_REQUIRE(witness_program_size > witness_v0_program_minimum_limit);
+        BOOST_REQUIRE(witness_program_size < witness_v0_program_maximum_limit);
 
         const auto result = build_chunk(
         {

--- a/test/wallet/witness_address.cpp
+++ b/test/wallet/witness_address.cpp
@@ -37,26 +37,30 @@ struct test_vector
     std::string hash;
     std::string address;
     bool testnet;
-    witness_address::encoding encoding;
+    uint8_t version;
     uint8_t witness_version;
 };
 
-typedef std::vector<test_vector> test_list;
-
-test_list native_witness_tests =
+const std::vector<test_vector> native_witness_p2wpkh_tests =
 {
-    // hash, address, testnet, encoding, witness_version
-    { "78f0c6aeafc418a10bc92c2bb24cdd2d27dc0a0b", "QWz8m8pbR6nqXJHEdtRTAxoQ6YHkxRNxLw7x", true, witness_address::encoding::testnet_base58_p2wpkh, 0 },
-    { "a2594531c857b98e4f1a8aa78e2edb74efe8ff37", "p2y9GjzzvXoHJ8WWMaYaz7hf8sv74LiU8dLK", false, witness_address::encoding::mainnet_base58_p2wpkh, 0 },
-    { "91df9b382022f8dbcf33a960d9c5d82e996d2020", "p2y7mdSZzcPLZL1S5woeBmafWvnE1yFk3H2f", false, witness_address::encoding::mainnet_base58_p2wpkh, 0 },
-    { "59bc07ec402a63b072f07115bfc83d73a8a88c1654c85e2dd64bc6aee40cc239", "T7nYVDjPz5V9vPCfBJq4R55LvFkA3ReMfbvT5AX6vxAEgZRGtKF5d", true, witness_address::encoding::testnet_base58_p2wsh, 0 },
-    { "0b1572dae6a95c50e7e8203b4de0d06291be349b9a8b9ef49d6389fc2f785dcf", "T7nXtahqZTvcSfU3QHhKSfJsTVb57oEM9aFRTQa6i5jnaUw5wvNAb", true, witness_address::encoding::testnet_base58_p2wsh, 0 },
-    { "99071ccd792c8bb97138de5817169043c09676872e8f90e6aab433f8e532a693", "7XhQN533dfoMqSCNMt85Pu77pmjXE84Pq9FSsVTb6Rzu5h8oAc8Tn", false, witness_address::encoding::mainnet_base58_p2wsh, 0 }
+    // hash, address, testnet, version, witness_version
+    { "78f0c6aeafc418a10bc92c2bb24cdd2d27dc0a0b", "QWz8m8pbR6nqXJHEdtRTAxoQ6YHkxRNxLw7x", true, witness_address::testnet_base58_p2wpkh, 0 },
+    { "a2594531c857b98e4f1a8aa78e2edb74efe8ff37", "p2y9GjzzvXoHJ8WWMaYaz7hf8sv74LiU8dLK", false, witness_address::mainnet_base58_p2wpkh, 0 },
+    { "91df9b382022f8dbcf33a960d9c5d82e996d2020", "p2y7mdSZzcPLZL1S5woeBmafWvnE1yFk3H2f", false, witness_address::mainnet_base58_p2wpkh, 0 },
+};
+
+const std::vector<test_vector> native_witness_p2wsh_tests =
+{
+    // hash, address, testnet, version, witness_version
+    { "59bc07ec402a63b072f07115bfc83d73a8a88c1654c85e2dd64bc6aee40cc239", "T7nYVDjPz5V9vPCfBJq4R55LvFkA3ReMfbvT5AX6vxAEgZRGtKF5d", true, witness_address::testnet_base58_p2wsh, 0 },
+    { "0b1572dae6a95c50e7e8203b4de0d06291be349b9a8b9ef49d6389fc2f785dcf", "T7nXtahqZTvcSfU3QHhKSfJsTVb57oEM9aFRTQa6i5jnaUw5wvNAb", true, witness_address::testnet_base58_p2wsh, 0 },
+    { "99071ccd792c8bb97138de5817169043c09676872e8f90e6aab433f8e532a693", "7XhQN533dfoMqSCNMt85Pu77pmjXE84Pq9FSsVTb6Rzu5h8oAc8Tn", false, witness_address::mainnet_base58_p2wsh, 0 }
 };
 
 // BIP 173 test constants.
 #define MAINNET_P2WPKH_ADDRESS "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
 #define TESTNET_P2WPKH_ADDRESS "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+#define TESTNET_P2WPKH_ADDRESS2 "tb1qr47dd36u96r0fjle36hdygdnp0v6pwfgqe6jxg"
 
 #define MAINNET_P2WSH_ADDRESS "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"
 #define MAINNET_P2WSH_SCRIPT "[0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798] checksig"
@@ -74,41 +78,49 @@ struct test_address
 
 typedef std::vector<test_address> test_address_list;
 
-test_address_list witness_address_tests =
+const test_address_list witness_address_zero_version_tests =
 {
     // witness address, decoded
     { "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4", "0014751e76e8199196d454941c45d1b3a323f1433bd6" },
     { "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7", "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262" },
-    { "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx", "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6" },
-    { "BC1SW50QA3JX3S", "6002751e" },
-    { "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj", "5210751e76e8199196d454941c45d1b3a323" },
     { "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy", "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433" }
 };
 
-BOOST_AUTO_TEST_CASE(witness_address__construct__to_p2wpkh__valid_expected)
+const test_address_list witness_address_nonzero_version_tests =
 {
-    const witness_address address(ec_public(BIP142_PUBLIC_KEY), witness_address::encoding::mainnet_base58_p2wpkh);
+    { "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx", "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6" },
+    { "BC1SW50QA3JX3S", "6002751e" },
+    { "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj", "5210751e76e8199196d454941c45d1b3a323" },
+};
+
+BOOST_AUTO_TEST_CASE(witness_address__construct__from_ec_public__valid_expected)
+{
+    const witness_address address(ec_public(BIP142_PUBLIC_KEY),
+        witness_address::mainnet_base58_p2wpkh);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH);
 }
 
 BOOST_AUTO_TEST_CASE(witness_address__construct__from_base58_p2wpkh_string__valid_expected)
 {
-    const witness_address address(std::string(ADDRESS_P2WPKH), witness_address::encoding::mainnet_base58_p2wpkh);
+    const witness_address address(std::string(ADDRESS_P2WPKH),
+        witness_address::mainnet_base58_p2wpkh);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH);
 }
 
 BOOST_AUTO_TEST_CASE(witness_address__construct__testnet_to_p2wpkh__valid_expected)
 {
-    const witness_address address(ec_public(BIP142_PUBLIC_KEY), witness_address::encoding::testnet_base58_p2wpkh);
+    const witness_address address(ec_public(BIP142_PUBLIC_KEY),
+        witness_address::testnet_base58_p2wpkh);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH_TESTNET);
 }
 
 BOOST_AUTO_TEST_CASE(witness_address__construct__testnet_to_p2wpkh_string__valid_expected)
 {
-    const witness_address address(std::string(ADDRESS_P2WPKH_TESTNET), witness_address::encoding::testnet_base58_p2wpkh);
+    const witness_address address(std::string(ADDRESS_P2WPKH_TESTNET),
+        witness_address::testnet_base58_p2wpkh);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH_TESTNET);
 }
@@ -117,7 +129,8 @@ BOOST_AUTO_TEST_CASE(witness_address__construct__mainnet_to_p2wsh__valid_expecte
 {
     chain::script script;
     script.from_string(MAINNET_P2WSH_SCRIPT);
-    const witness_address address(script, witness_address::encoding::mainnet_p2wsh);
+    const witness_address address(script, witness_address::mainnet_bech32_p2wsh,
+        witness_address::mainnet_prefix);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), MAINNET_P2WSH_ADDRESS);
 }
@@ -126,75 +139,72 @@ BOOST_AUTO_TEST_CASE(witness_address__construct__testnet_to_p2wsh__valid_expecte
 {
     chain::script script;
     script.from_string(TESTNET_P2WSH_SCRIPT);
-    const witness_address address(script, witness_address::encoding::testnet_p2wsh);
+    const witness_address address(script, witness_address::testnet_bech32_p2wsh,
+        witness_address::testnet_prefix);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), TESTNET_P2WSH_ADDRESS);
 }
 
-BOOST_AUTO_TEST_CASE(witness_address__construct__witness_data_to_testnet_p2wpkh__valid_expected)
+BOOST_AUTO_TEST_CASE(witness_address__construct__ec_public_to_testnet_p2wpkh__valid_expected)
 {
     // Based on witness data from:
     // https://www.blockchain.com/btctest/tx/d869f854e1f8788bcff294cc83b280942a8c728de71eb709a2c29d10bfe21b7c
 
-    // Create witness address from public key data(_chunk).
-    data_chunk witness_data;
-    decode_base16(witness_data, std::string("038262a6c6cec93c2d3ecd6c6072efea86d02ff8e3328bbd0242b20af3425990ac"));
-    const witness_address address(witness_data, witness_address::encoding::testnet_p2wpkh);
-    BOOST_REQUIRE_EQUAL(address.bech32("tb"), "tb1qr47dd36u96r0fjle36hdygdnp0v6pwfgqe6jxg");
-
     // Create the same witness address from ec_public.
-    const witness_address address2(ec_public("038262a6c6cec93c2d3ecd6c6072efea86d02ff8e3328bbd0242b20af3425990ac"), witness_address::encoding::testnet_p2wpkh);
+    const std::string test_public_key =
+        "038262a6c6cec93c2d3ecd6c6072efea86d02ff8e3328bbd0242b20af3425990ac";
+    const witness_address address(ec_public(test_public_key),
+        witness_address::testnet_bech32_p2wpkh,
+        witness_address::testnet_prefix);
 
-    // Ensure they encode equally.
-    BOOST_REQUIRE_EQUAL(address.bech32("tb"), address2.bech32("tb"));
-    BOOST_REQUIRE_EQUAL(address.encoded(), address2.encoded());
+    BOOST_REQUIRE(address);
+    BOOST_REQUIRE_EQUAL(address.bech32(), TESTNET_P2WPKH_ADDRESS2);
+    BOOST_REQUIRE_EQUAL(address.encoded(), TESTNET_P2WPKH_ADDRESS2);
 }
 
-BOOST_AUTO_TEST_CASE(witness_address__witness_vectors__valid_expected)
+BOOST_AUTO_TEST_CASE(witness_address__witness_p2wpkh_vectors__valid_expected)
 {
-    for (const auto& test: native_witness_tests)
+    for (const auto& test: native_witness_p2wpkh_tests)
     {
-        if (test.encoding == witness_address::encoding::mainnet_base58_p2wpkh ||
-            test.encoding == witness_address::encoding::testnet_base58_p2wpkh)
-        {
-            short_hash hash;
-            BOOST_REQUIRE(decode_base16(hash, test.hash));
-            const witness_address address(hash, test.encoding);
-            BOOST_REQUIRE(address);
-            BOOST_REQUIRE_EQUAL(address.encoded(), test.address);
-        }
-        else
-        {
-            hash_digest hash;
-            BOOST_REQUIRE(decode_base16(hash, test.hash));
-            const witness_address address(hash, test.encoding);
-            BOOST_REQUIRE(address);
-            BOOST_REQUIRE_EQUAL(address.encoded(), test.address);
-        }
+        short_hash hash;
+        BOOST_REQUIRE(decode_base16(hash, test.hash));
+        const witness_address address(hash, test.version);
+        BOOST_REQUIRE(address);
+        BOOST_REQUIRE_EQUAL(address.encoded(), test.address);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(witness_address__witness_p2wsh_vectors__valid_expected)
+{
+    for (const auto& test: native_witness_p2wsh_tests)
+    {
+        hash_digest hash;
+        BOOST_REQUIRE(decode_base16(hash, test.hash));
+        const witness_address address(hash, test.version);
+        BOOST_REQUIRE(address);
+        BOOST_REQUIRE_EQUAL(address.encoded(), test.address);
     }
 }
 
 struct witness_address_accessor
   : public witness_address
 {
-    data_chunk convert_bits(uint32_t from_bits, uint32_t to_bits,
-        bool pad, const data_chunk& in, size_t in_offset)
+    data_chunk convert_bits(uint32_t from_bits, uint32_t to_bits, bool pad,
+        const data_chunk& in, size_t in_offset)
     {
-        return witness_address::convert_bits(
-            from_bits, to_bits, pad, in, in_offset);
+        return witness_address::convert_bits(from_bits, to_bits, pad, in,
+            in_offset);
     }
 };
 
-BOOST_AUTO_TEST_CASE(base32__witness_address_vectors__valid_expected)
+BOOST_AUTO_TEST_CASE(base32__witness_address_zero_version_tests__valid_expected)
 {
-    for (const auto& test: witness_address_tests)
+    for (const auto& test: witness_address_zero_version_tests)
     {
         base32 decoded;
         BOOST_REQUIRE(decode_base32(decoded, test.address));
         uint8_t witness_version = decoded.payload.front();
-        // https://github.com/sipa/bech32/blob/master/ref/javascript/tests.js#L24
-        if (witness_version != 0)
-            witness_version += 0x50;
+        BOOST_REQUIRE(witness_version == 0);
 
         witness_address_accessor converter;
         const auto witness_program = converter.convert_bits(5, 8, false,
@@ -204,8 +214,50 @@ BOOST_AUTO_TEST_CASE(base32__witness_address_vectors__valid_expected)
         const auto witness_program_size = static_cast<uint8_t>(
             witness_program.size());
 
-        data_chunk result = { witness_version, witness_program_size };
-        extend_data(result, witness_program);
+        const auto result = build_chunk(
+        {
+            to_chunk(witness_version),
+            to_chunk(witness_program_size),
+            witness_program
+        });
+
+        BOOST_REQUIRE_EQUAL(encode_base16(result), test.decoded);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(base32__witness_address_nonzero_version_tests__valid_expected)
+{
+    // This op_version gap is used to normalize the value difference
+    // between the defined OP_0 opcode (value 0) and the OP_1 opcode
+    // (value 0x51)
+    const auto op_version_gap = 0x50;
+    const auto witness_v0_program_minimum_limit = 1;
+    const auto witness_v0_program_maximum_limit = 41;
+
+    for (const auto& test: witness_address_nonzero_version_tests)
+    {
+        base32 decoded;
+        BOOST_REQUIRE(decode_base32(decoded, test.address));
+        uint8_t witness_version = decoded.payload.front();
+        BOOST_REQUIRE(witness_version != 0);
+        witness_version += op_version_gap;
+
+        witness_address_accessor converter;
+        const auto witness_program = converter.convert_bits(5, 8, false,
+            decoded.payload, 1);
+
+        const auto witness_program_size = static_cast<uint8_t>(
+            witness_program.size());
+        BOOST_REQUIRE(witness_program_size > witness_v0_program_minimum_limit &&
+                      witness_program_size < witness_v0_program_maximum_limit);
+
+        const auto result = build_chunk(
+        {
+            to_chunk(witness_version),
+            to_chunk(witness_program_size),
+            witness_program
+        });
+
         BOOST_REQUIRE_EQUAL(encode_base16(result), test.decoded);
     }
 }

--- a/test/wallet/witness_address.cpp
+++ b/test/wallet/witness_address.cpp
@@ -46,12 +46,12 @@ typedef std::vector<test_vector> test_list;
 test_list native_witness_tests =
 {
     // hash, address, testnet, encoding, witness_version
-    { "78f0c6aeafc418a10bc92c2bb24cdd2d27dc0a0b", "QWz8m8pbR6nqXJHEdtRTAxoQ6YHkxRNxLw7x", true, witness_address::encoding::testnet_p2sh_p2wpkh, 0 },
-    { "a2594531c857b98e4f1a8aa78e2edb74efe8ff37", "p2y9GjzzvXoHJ8WWMaYaz7hf8sv74LiU8dLK", false, witness_address::encoding::mainnet_p2sh_p2wpkh, 0 },
-    { "91df9b382022f8dbcf33a960d9c5d82e996d2020", "p2y7mdSZzcPLZL1S5woeBmafWvnE1yFk3H2f", false, witness_address::encoding::mainnet_p2sh_p2wpkh, 0 },
-    { "59bc07ec402a63b072f07115bfc83d73a8a88c1654c85e2dd64bc6aee40cc239", "T7nYVDjPz5V9vPCfBJq4R55LvFkA3ReMfbvT5AX6vxAEgZRGtKF5d", true, witness_address::encoding::testnet_p2sh_p2wsh, 0 },
-    { "0b1572dae6a95c50e7e8203b4de0d06291be349b9a8b9ef49d6389fc2f785dcf", "T7nXtahqZTvcSfU3QHhKSfJsTVb57oEM9aFRTQa6i5jnaUw5wvNAb", true, witness_address::encoding::testnet_p2sh_p2wsh, 0 },
-    { "99071ccd792c8bb97138de5817169043c09676872e8f90e6aab433f8e532a693", "7XhQN533dfoMqSCNMt85Pu77pmjXE84Pq9FSsVTb6Rzu5h8oAc8Tn", false, witness_address::encoding::mainnet_p2sh_p2wsh, 0 }
+    { "78f0c6aeafc418a10bc92c2bb24cdd2d27dc0a0b", "QWz8m8pbR6nqXJHEdtRTAxoQ6YHkxRNxLw7x", true, witness_address::encoding::testnet_base58_p2wpkh, 0 },
+    { "a2594531c857b98e4f1a8aa78e2edb74efe8ff37", "p2y9GjzzvXoHJ8WWMaYaz7hf8sv74LiU8dLK", false, witness_address::encoding::mainnet_base58_p2wpkh, 0 },
+    { "91df9b382022f8dbcf33a960d9c5d82e996d2020", "p2y7mdSZzcPLZL1S5woeBmafWvnE1yFk3H2f", false, witness_address::encoding::mainnet_base58_p2wpkh, 0 },
+    { "59bc07ec402a63b072f07115bfc83d73a8a88c1654c85e2dd64bc6aee40cc239", "T7nYVDjPz5V9vPCfBJq4R55LvFkA3ReMfbvT5AX6vxAEgZRGtKF5d", true, witness_address::encoding::testnet_base58_p2wsh, 0 },
+    { "0b1572dae6a95c50e7e8203b4de0d06291be349b9a8b9ef49d6389fc2f785dcf", "T7nXtahqZTvcSfU3QHhKSfJsTVb57oEM9aFRTQa6i5jnaUw5wvNAb", true, witness_address::encoding::testnet_base58_p2wsh, 0 },
+    { "99071ccd792c8bb97138de5817169043c09676872e8f90e6aab433f8e532a693", "7XhQN533dfoMqSCNMt85Pu77pmjXE84Pq9FSsVTb6Rzu5h8oAc8Tn", false, witness_address::encoding::mainnet_base58_p2wsh, 0 }
 };
 
 // BIP 173 test constants.
@@ -87,28 +87,28 @@ test_address_list witness_address_tests =
 
 BOOST_AUTO_TEST_CASE(witness_address__construct__to_p2wpkh__valid_expected)
 {
-    const witness_address address(ec_public(BIP142_PUBLIC_KEY), witness_address::encoding::mainnet_p2sh_p2wpkh);
+    const witness_address address(ec_public(BIP142_PUBLIC_KEY), witness_address::encoding::mainnet_base58_p2wpkh);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH);
 }
 
-BOOST_AUTO_TEST_CASE(witness_address__construct__from_p2sh_p2wpkh_string__valid_expected)
+BOOST_AUTO_TEST_CASE(witness_address__construct__from_base58_p2wpkh_string__valid_expected)
 {
-    const witness_address address(std::string(ADDRESS_P2WPKH), witness_address::encoding::mainnet_p2sh_p2wpkh);
+    const witness_address address(std::string(ADDRESS_P2WPKH), witness_address::encoding::mainnet_base58_p2wpkh);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH);
 }
 
 BOOST_AUTO_TEST_CASE(witness_address__construct__testnet_to_p2wpkh__valid_expected)
 {
-    const witness_address address(ec_public(BIP142_PUBLIC_KEY), witness_address::encoding::testnet_p2sh_p2wpkh);
+    const witness_address address(ec_public(BIP142_PUBLIC_KEY), witness_address::encoding::testnet_base58_p2wpkh);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH_TESTNET);
 }
 
 BOOST_AUTO_TEST_CASE(witness_address__construct__testnet_to_p2wpkh_string__valid_expected)
 {
-    const witness_address address(std::string(ADDRESS_P2WPKH_TESTNET), witness_address::encoding::testnet_p2sh_p2wpkh);
+    const witness_address address(std::string(ADDRESS_P2WPKH_TESTNET), witness_address::encoding::testnet_base58_p2wpkh);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH_TESTNET);
 }
@@ -154,8 +154,8 @@ BOOST_AUTO_TEST_CASE(witness_address__witness_vectors__valid_expected)
 {
     for (const auto& test: native_witness_tests)
     {
-        if (test.encoding == witness_address::encoding::mainnet_p2sh_p2wpkh ||
-            test.encoding == witness_address::encoding::testnet_p2sh_p2wpkh)
+        if (test.encoding == witness_address::encoding::mainnet_base58_p2wpkh ||
+            test.encoding == witness_address::encoding::testnet_base58_p2wpkh)
         {
             short_hash hash;
             BOOST_REQUIRE(decode_base16(hash, test.hash));

--- a/test/wallet/witness_address.cpp
+++ b/test/wallet/witness_address.cpp
@@ -25,38 +25,6 @@ using namespace bc::system::wallet;
 
 BOOST_AUTO_TEST_SUITE(witness_address_tests)
 
-// BIP 142 test constants.
-#define BIP142_PUBLIC_KEY "0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6"
-#define ADDRESS_P2WPKH "p2xtZoXeX5X8BP8JfFhQK2nD3emtjch7UeFm"
-#define ADDRESS_P2WPKH_TESTNET "QWywq9EVRcURXVarfKmHtyZ1MUGY4sJy5Dpq"
-
-// BIP 142 witness test vectors
-// https://github.com/theuni/bitcoin/blob/segwit-bip142/src/test/data/base58_keys_valid.json
-struct test_vector
-{
-    std::string hash;
-    std::string address;
-    bool testnet;
-    uint8_t version;
-    uint8_t witness_version;
-};
-
-const std::vector<test_vector> native_witness_p2wpkh_tests =
-{
-    // hash, address, testnet, version, witness_version
-    { "78f0c6aeafc418a10bc92c2bb24cdd2d27dc0a0b", "QWz8m8pbR6nqXJHEdtRTAxoQ6YHkxRNxLw7x", true, witness_address::testnet_base58_p2wpkh, 0 },
-    { "a2594531c857b98e4f1a8aa78e2edb74efe8ff37", "p2y9GjzzvXoHJ8WWMaYaz7hf8sv74LiU8dLK", false, witness_address::mainnet_base58_p2wpkh, 0 },
-    { "91df9b382022f8dbcf33a960d9c5d82e996d2020", "p2y7mdSZzcPLZL1S5woeBmafWvnE1yFk3H2f", false, witness_address::mainnet_base58_p2wpkh, 0 },
-};
-
-const std::vector<test_vector> native_witness_p2wsh_tests =
-{
-    // hash, address, testnet, version, witness_version
-    { "59bc07ec402a63b072f07115bfc83d73a8a88c1654c85e2dd64bc6aee40cc239", "T7nYVDjPz5V9vPCfBJq4R55LvFkA3ReMfbvT5AX6vxAEgZRGtKF5d", true, witness_address::testnet_base58_p2wsh, 0 },
-    { "0b1572dae6a95c50e7e8203b4de0d06291be349b9a8b9ef49d6389fc2f785dcf", "T7nXtahqZTvcSfU3QHhKSfJsTVb57oEM9aFRTQa6i5jnaUw5wvNAb", true, witness_address::testnet_base58_p2wsh, 0 },
-    { "99071ccd792c8bb97138de5817169043c09676872e8f90e6aab433f8e532a693", "7XhQN533dfoMqSCNMt85Pu77pmjXE84Pq9FSsVTb6Rzu5h8oAc8Tn", false, witness_address::mainnet_base58_p2wsh, 0 }
-};
-
 // BIP 173 test constants.
 #define MAINNET_P2WPKH_ADDRESS "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
 #define TESTNET_P2WPKH_ADDRESS "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
@@ -93,39 +61,11 @@ const test_address_list witness_address_nonzero_version_tests =
     { "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj", "5210751e76e8199196d454941c45d1b3a323" },
 };
 
-BOOST_AUTO_TEST_CASE(witness_address__construct__from_ec_public__valid_expected)
-{
-    const witness_address address(ec_public(BIP142_PUBLIC_KEY), witness_address::mainnet_base58_p2wpkh);
-    BOOST_REQUIRE(address);
-    BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH);
-}
-
-BOOST_AUTO_TEST_CASE(witness_address__construct__from_base58_p2wpkh_string__valid_expected)
-{
-    const witness_address address(std::string(ADDRESS_P2WPKH), witness_address::mainnet_base58_p2wpkh);
-    BOOST_REQUIRE(address);
-    BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH);
-}
-
-BOOST_AUTO_TEST_CASE(witness_address__construct__testnet_to_p2wpkh__valid_expected)
-{
-    const witness_address address(ec_public(BIP142_PUBLIC_KEY), witness_address::testnet_base58_p2wpkh);
-    BOOST_REQUIRE(address);
-    BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH_TESTNET);
-}
-
-BOOST_AUTO_TEST_CASE(witness_address__construct__testnet_to_p2wpkh_string__valid_expected)
-{
-    const witness_address address(std::string(ADDRESS_P2WPKH_TESTNET), witness_address::testnet_base58_p2wpkh);
-    BOOST_REQUIRE(address);
-    BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH_TESTNET);
-}
-
 BOOST_AUTO_TEST_CASE(witness_address__construct__mainnet_to_p2wsh__valid_expected)
 {
     chain::script script;
     script.from_string(MAINNET_P2WSH_SCRIPT);
-    const witness_address address(script, witness_address::mainnet_bech32_p2wsh, witness_address::mainnet_prefix);
+    const witness_address address(script, witness_address::address_format::p2wsh, witness_address::mainnet_prefix);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), MAINNET_P2WSH_ADDRESS);
 }
@@ -134,7 +74,7 @@ BOOST_AUTO_TEST_CASE(witness_address__construct__testnet_to_p2wsh__valid_expecte
 {
     chain::script script;
     script.from_string(TESTNET_P2WSH_SCRIPT);
-    const witness_address address(script, witness_address::testnet_bech32_p2wsh, witness_address::testnet_prefix);
+    const witness_address address(script, witness_address::address_format::p2wsh, witness_address::testnet_prefix);
     BOOST_REQUIRE(address);
     BOOST_REQUIRE_EQUAL(address.encoded(), TESTNET_P2WSH_ADDRESS);
 }
@@ -146,35 +86,10 @@ BOOST_AUTO_TEST_CASE(witness_address__construct__ec_public_to_testnet_p2wpkh__va
 
     // Create the same witness address from ec_public.
     const std::string test_public_key = "038262a6c6cec93c2d3ecd6c6072efea86d02ff8e3328bbd0242b20af3425990ac";
-    const witness_address address(ec_public(test_public_key), witness_address::testnet_bech32_p2wpkh, witness_address::testnet_prefix);
+    const witness_address address(ec_public(test_public_key), witness_address::address_format::p2wpkh, witness_address::testnet_prefix);
 
     BOOST_REQUIRE(address);
-    BOOST_REQUIRE_EQUAL(address.bech32(), TESTNET_P2WPKH_ADDRESS2);
     BOOST_REQUIRE_EQUAL(address.encoded(), TESTNET_P2WPKH_ADDRESS2);
-}
-
-BOOST_AUTO_TEST_CASE(witness_address__witness_p2wpkh_vectors__valid_expected)
-{
-    for (const auto& test: native_witness_p2wpkh_tests)
-    {
-        short_hash hash;
-        BOOST_REQUIRE(decode_base16(hash, test.hash));
-        const witness_address address(hash, test.version);
-        BOOST_REQUIRE(address);
-        BOOST_REQUIRE_EQUAL(address.encoded(), test.address);
-    }
-}
-
-BOOST_AUTO_TEST_CASE(witness_address__witness_p2wsh_vectors__valid_expected)
-{
-    for (const auto& test: native_witness_p2wsh_tests)
-    {
-        hash_digest hash;
-        BOOST_REQUIRE(decode_base16(hash, test.hash));
-        const witness_address address(hash, test.version);
-        BOOST_REQUIRE(address);
-        BOOST_REQUIRE_EQUAL(address.encoded(), test.address);
-    }
 }
 
 struct witness_address_accessor

--- a/test/wallet/witness_address.cpp
+++ b/test/wallet/witness_address.cpp
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2011-2019 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <boost/test/unit_test.hpp>
+#include <bitcoin/system.hpp>
+
+using namespace bc::system;
+using namespace bc::system::chain;
+using namespace bc::system::wallet;
+
+BOOST_AUTO_TEST_SUITE(witness_address_tests)
+
+// BIP 142 test constants.
+#define BIP142_PUBLIC_KEY "0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6"
+#define ADDRESS_P2WPKH "p2xtZoXeX5X8BP8JfFhQK2nD3emtjch7UeFm"
+#define ADDRESS_P2WPKH_TESTNET "QWywq9EVRcURXVarfKmHtyZ1MUGY4sJy5Dpq"
+
+// BIP 142 witness test vectors
+// https://github.com/theuni/bitcoin/blob/segwit-bip142/src/test/data/base58_keys_valid.json
+struct test_vector
+{
+    std::string hash;
+    std::string address;
+    bool testnet;
+    witness_address::encoding encoding;
+    uint8_t witness_version;
+};
+
+typedef std::vector<test_vector> test_list;
+
+test_list native_witness_tests =
+{
+    // hash, address, testnet, encoding, witness_version
+    { "78f0c6aeafc418a10bc92c2bb24cdd2d27dc0a0b", "QWz8m8pbR6nqXJHEdtRTAxoQ6YHkxRNxLw7x", true, witness_address::encoding::testnet_p2sh_p2wpkh, 0 },
+    { "a2594531c857b98e4f1a8aa78e2edb74efe8ff37", "p2y9GjzzvXoHJ8WWMaYaz7hf8sv74LiU8dLK", false, witness_address::encoding::mainnet_p2sh_p2wpkh, 0 },
+    { "91df9b382022f8dbcf33a960d9c5d82e996d2020", "p2y7mdSZzcPLZL1S5woeBmafWvnE1yFk3H2f", false, witness_address::encoding::mainnet_p2sh_p2wpkh, 0 },
+    { "59bc07ec402a63b072f07115bfc83d73a8a88c1654c85e2dd64bc6aee40cc239", "T7nYVDjPz5V9vPCfBJq4R55LvFkA3ReMfbvT5AX6vxAEgZRGtKF5d", true, witness_address::encoding::testnet_p2sh_p2wsh, 0 },
+    { "0b1572dae6a95c50e7e8203b4de0d06291be349b9a8b9ef49d6389fc2f785dcf", "T7nXtahqZTvcSfU3QHhKSfJsTVb57oEM9aFRTQa6i5jnaUw5wvNAb", true, witness_address::encoding::testnet_p2sh_p2wsh, 0 },
+    { "99071ccd792c8bb97138de5817169043c09676872e8f90e6aab433f8e532a693", "7XhQN533dfoMqSCNMt85Pu77pmjXE84Pq9FSsVTb6Rzu5h8oAc8Tn", false, witness_address::encoding::mainnet_p2sh_p2wsh, 0 }
+};
+
+// BIP 173 test constants.
+#define MAINNET_P2WPKH_ADDRESS "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+#define TESTNET_P2WPKH_ADDRESS "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+
+#define MAINNET_P2WSH_ADDRESS "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"
+#define MAINNET_P2WSH_SCRIPT "[0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798] checksig"
+
+#define TESTNET_P2WSH_ADDRESS "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7"
+#define TESTNET_P2WSH_SCRIPT "[0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798] checksig"
+
+// BIP 173 witness address vectors
+// https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#test-vectors
+struct test_address
+{
+    std::string address;
+    std::string decoded;
+};
+
+typedef std::vector<test_address> test_address_list;
+
+test_address_list witness_address_tests =
+{
+    // witness address, decoded
+    { "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4", "0014751e76e8199196d454941c45d1b3a323f1433bd6" },
+    { "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7", "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262" },
+    { "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx", "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6" },
+    { "BC1SW50QA3JX3S", "6002751e" },
+    { "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj", "5210751e76e8199196d454941c45d1b3a323" },
+    { "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy", "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433" }
+};
+
+BOOST_AUTO_TEST_CASE(witness_address__construct__public_to_p2wpkh__valid_expected)
+{
+    const witness_address address(ec_public(BIP142_PUBLIC_KEY), witness_address::encoding::mainnet_p2sh_p2wpkh);
+    BOOST_REQUIRE(address);
+    BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH);
+}
+
+BOOST_AUTO_TEST_CASE(witness_address__construct__from_p2sh_p2wpkh_string__valid_expected)
+{
+    const witness_address address(std::string(ADDRESS_P2WPKH), witness_address::encoding::mainnet_p2sh_p2wpkh);
+    BOOST_REQUIRE(address);
+    BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH);
+}
+
+BOOST_AUTO_TEST_CASE(witness_address__construct__public_testnet_to_p2wpkh__valid_expected)
+{
+    const witness_address address(ec_public(BIP142_PUBLIC_KEY), witness_address::encoding::testnet_p2sh_p2wpkh);
+    BOOST_REQUIRE(address);
+    BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH_TESTNET);
+}
+
+BOOST_AUTO_TEST_CASE(witness_address__construct__public_testnet_to_p2wpkh_string__valid_expected)
+{
+    const witness_address address(std::string(ADDRESS_P2WPKH_TESTNET), witness_address::encoding::testnet_p2sh_p2wpkh);
+    BOOST_REQUIRE(address);
+    BOOST_REQUIRE_EQUAL(address.encoded(), ADDRESS_P2WPKH_TESTNET);
+}
+
+BOOST_AUTO_TEST_CASE(witness_address__construct__public_mainnet_to_p2wsh__valid_expected)
+{
+    chain::script script;
+    script.from_string(MAINNET_P2WSH_SCRIPT);
+    const witness_address address(script, witness_address::encoding::mainnet_p2wsh);
+    BOOST_REQUIRE(address);
+    BOOST_REQUIRE_EQUAL(address.encoded(), MAINNET_P2WSH_ADDRESS);
+}
+
+BOOST_AUTO_TEST_CASE(witness_address__construct__public_testnet_to_p2wsh__valid_expected)
+{
+    chain::script script;
+    script.from_string(TESTNET_P2WSH_SCRIPT);
+    const witness_address address(script, witness_address::encoding::testnet_p2wsh);
+    BOOST_REQUIRE(address);
+    BOOST_REQUIRE_EQUAL(address.encoded(), TESTNET_P2WSH_ADDRESS);
+}
+
+BOOST_AUTO_TEST_CASE(witness_address__construct__witness_data_to_testnet_p2wpkh__valid_expected)
+{
+    // Based on witness data from:
+    // https://www.blockchain.com/btctest/tx/d869f854e1f8788bcff294cc83b280942a8c728de71eb709a2c29d10bfe21b7c
+
+    // Create witness address from public key data(_chunk).
+    data_chunk witness_data;
+    decode_base16(witness_data, std::string("038262a6c6cec93c2d3ecd6c6072efea86d02ff8e3328bbd0242b20af3425990ac"));
+    const witness_address address(witness_data, witness_address::encoding::testnet_p2wpkh);
+    BOOST_REQUIRE_EQUAL(address.bech32("tb"), "tb1qr47dd36u96r0fjle36hdygdnp0v6pwfgqe6jxg");
+
+    // Create the same witness address from ec_public.
+    const witness_address address2(ec_public("038262a6c6cec93c2d3ecd6c6072efea86d02ff8e3328bbd0242b20af3425990ac"), witness_address::encoding::testnet_p2wpkh);
+
+    // Ensure they encode equally.
+    BOOST_REQUIRE_EQUAL(address.bech32("tb"), address2.bech32("tb"));
+    BOOST_REQUIRE_EQUAL(address.encoded(), address2.encoded());
+}
+
+BOOST_AUTO_TEST_CASE(witness_address__witness_vectors__valid_expected)
+{
+    for (const auto& test: native_witness_tests)
+    {
+        if (test.encoding == witness_address::encoding::mainnet_p2sh_p2wpkh ||
+            test.encoding == witness_address::encoding::testnet_p2sh_p2wpkh)
+        {
+            short_hash hash;
+            BOOST_REQUIRE(decode_base16(hash, test.hash));
+            const witness_address address(hash, test.encoding);
+            BOOST_REQUIRE(address);
+            BOOST_REQUIRE_EQUAL(address.encoded(), test.address);
+        }
+        else
+        {
+            hash_digest hash;
+            BOOST_REQUIRE(decode_base16(hash, test.hash));
+            const witness_address address(hash, test.encoding);
+            BOOST_REQUIRE(address);
+            BOOST_REQUIRE_EQUAL(address.encoded(), test.address);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(base32__witness_address_vectors__valid_expected)
+{
+    for (const auto& test: witness_address_tests)
+    {
+        base32 decoded;
+        BOOST_REQUIRE(decode_base32(decoded, test.address));
+        uint8_t witness_version = decoded.payload.front();
+        // https://github.com/sipa/bech32/blob/master/ref/javascript/tests.js#L24
+        if (witness_version != 0)
+            witness_version += 0x50;
+
+        const auto witness_program = witness_address::convert_bits(5, 8, false,
+            decoded.payload, 1);
+        BOOST_REQUIRE(witness_program.size() > 1 &&
+                      witness_program.size() < 41);
+        const auto witness_program_size = static_cast<uint8_t>(
+            witness_program.size());
+
+        data_chunk result = { witness_version, witness_program_size };
+        extend_data(result, witness_program);
+        BOOST_REQUIRE_EQUAL(encode_base16(result), test.decoded);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add payment address parsing and tests for standard witness scripts, including address formats specified in BIP 142 and BIP 173 (v0 only).

Resolves #844