### PR TITLE
Remove duplicate code in timer

### DIFF
--- a/include/bitcoin/system/utility/timer.hpp
+++ b/include/bitcoin/system/utility/timer.hpp
@@ -64,11 +64,7 @@ struct timer
     template <typename Function, typename ...Args>
     static typename Time::rep execution(Function func, Args&&... args)
     {
-        const auto start = Clock::now();
-        func(std::forward<Args>(args)...);
-        const auto difference = Clock::now() - start;
-        const auto duration = std::chrono::duration_cast<Time>(difference);
-        return duration.count();
+        return duration(func, std::forward<Args>(args)...).count();
     }
 
     /// Returns the duration (in chrono's type system) of the elapsed time.


### PR DESCRIPTION
This code is not needed, since the std::forward optimizes out the intervening function call and the result is exactly similar.