### PR TITLE
Update supported compilers list in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ Visual Studio solutions are maintained for all libbitcoin libraries. NuGet packa
 
 Libbitcoin requires a C++11 compiler, which means Visual Studio 2013 (with a pre-release compiler update) or later. Download and install one of the following free tools as necessary:
 
-* [Visual Studio 2017 Express](https://www.visualstudio.com/downloads)
+* [Visual Studio 2019 Community](https://www.visualstudio.com/downloads)
+* [Visual Studio 2017 Community](https://www.visualstudio.com/vs/older-downloads)
 * [Visual Studio 2015 Express](https://www.visualstudio.com/vs/older-downloads)
 * [Visual Studio 2013 Express](https://www.visualstudio.com/vs/older-downloads)
   * [November 2013 CTP Compiler for Visual Studio 2013](http://www.microsoft.com/en-us/download/details.aspx?id=41151)

--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ Visual Studio solutions are maintained for all libbitcoin libraries. NuGet packa
 
 Libbitcoin requires a C++11 compiler, which means Visual Studio 2013 (with a pre-release compiler update) or later. Download and install one of the following free tools as necessary:
 
-* [Visual Studio 2019 Community](https://www.visualstudio.com/downloads)
 * [Visual Studio 2017 Community](https://www.visualstudio.com/vs/older-downloads)
 * [Visual Studio 2015 Express](https://www.visualstudio.com/vs/older-downloads)
 * [Visual Studio 2013 Express](https://www.visualstudio.com/vs/older-downloads)


### PR DESCRIPTION
~~- Added link to Visual Studio 2019 Community edition (free edition).~~
- Renamed Visual Studio 2017 Express link to correct name of Community.
- Changed 2017 edition link to the older downloads page, as the current download link redirects to the 2019 edition.