### PR TITLE
 Don't modify const, normalize math ops, add test cases, style.

### DIFF
--- a/include/bitcoin/system/math/ec_scalar.hpp
+++ b/include/bitcoin/system/math/ec_scalar.hpp
@@ -19,6 +19,7 @@
 #ifndef LIBBITCOIN_SYSTEM_EC_SCALAR_HPP
 #define LIBBITCOIN_SYSTEM_EC_SCALAR_HPP
 
+#include <cstdint>
 #include <memory>
 #include <bitcoin/system/define.hpp>
 #include <bitcoin/system/math/elliptic_curve.hpp>
@@ -33,21 +34,21 @@ public:
 
     /// Constructors.
     ec_scalar();
-    explicit ec_scalar(uint64_t value);
     ec_scalar(const ec_secret& secret);
     ec_scalar(const ec_scalar& scalar);
     ec_scalar(ec_scalar&& scalar);
-    ~ec_scalar() = default;
+    ec_scalar(uint64_t value);
 
     /// Operators.
-    ec_scalar& operator=(uint64_t value);
     ec_scalar& operator=(const ec_secret& secret);
     ec_scalar& operator=(const ec_scalar& scalar);
     ec_scalar& operator=(ec_scalar&& scalar);
+    ec_scalar& operator=(uint64_t value);
 
-    ec_scalar operator-() const;
+    ec_scalar operator-();
     ec_scalar& operator+=(const ec_scalar& scalar);
     ec_scalar& operator-=(const ec_scalar& scalar);
+    ec_scalar& operator*=(const ec_scalar& scalar);
 
     /// Cast operators.
     operator bool() const;
@@ -57,20 +58,18 @@ public:
     const ec_secret& secret() const;
 
 protected:
-    friend ec_scalar operator+(ec_scalar left, const ec_scalar& right);
-    friend ec_scalar operator-(ec_scalar left, const ec_scalar& right);
-    friend ec_scalar operator*(ec_scalar left, const ec_scalar& right);
+    friend ec_scalar operator+(const ec_scalar& left, const ec_scalar& right);
+    friend ec_scalar operator-(const ec_scalar& left, const ec_scalar& right);
+    friend ec_scalar operator*(const ec_scalar& left, const ec_scalar& right);
 
-    using ec_secret_uptr = std::unique_ptr<ec_secret>;
-
-    ec_secret_uptr secret_;
+    std::unique_ptr<ec_secret> secret_;
 };
 
 bool operator==(const ec_scalar& left, const ec_scalar& right);
 bool operator!=(const ec_scalar& left, const ec_scalar& right);
-ec_scalar operator+(ec_scalar left, const ec_scalar& right);
-ec_scalar operator-(ec_scalar left, const ec_scalar& right);
-ec_scalar operator*(ec_scalar left, const ec_scalar& right);
+ec_scalar operator+(const ec_scalar& left, const ec_scalar& right);
+ec_scalar operator-(const ec_scalar& left, const ec_scalar& right);
+ec_scalar operator*(const ec_scalar& left, const ec_scalar& right);
 
 } // namespace system
 } // namespace libbitcoin

--- a/include/bitcoin/system/math/ec_scalar.hpp
+++ b/include/bitcoin/system/math/ec_scalar.hpp
@@ -62,7 +62,7 @@ protected:
     friend ec_scalar operator-(const ec_scalar& left, const ec_scalar& right);
     friend ec_scalar operator*(const ec_scalar& left, const ec_scalar& right);
 
-    std::unique_ptr<ec_secret> secret_;
+    std::shared_ptr<ec_secret> secret_;
 };
 
 bool operator==(const ec_scalar& left, const ec_scalar& right);

--- a/src/math/ec_scalar.cpp
+++ b/src/math/ec_scalar.cpp
@@ -121,7 +121,7 @@ ec_scalar& ec_scalar::operator-=(const ec_scalar& scalar)
     // TODO: any way to avoid copy (cannot change const parameter)?
     auto copy = scalar;
 
-    if (!(*this) || !scalar || !(ec_add(*secret_, -copy)))
+    if (!(*this) || !scalar || !ec_add(*secret_, -copy))
         secret_.reset();
 
     return *this;

--- a/src/math/ec_scalar.cpp
+++ b/src/math/ec_scalar.cpp
@@ -19,6 +19,8 @@
 #include <bitcoin/system/math/ec_scalar.hpp>
 
 #include <algorithm>
+#include <array>
+#include <utility>
 #include <bitcoin/system/math/hash.hpp>
 #include <bitcoin/system/math/elliptic_curve.hpp>
 #include <bitcoin/system/utility/serializer.hpp>
@@ -30,13 +32,8 @@ const ec_scalar ec_scalar::zero(0);
 
 ec_scalar::ec_scalar()
 {
-    // Avoid initializing secret by default.
-    // Helps when you pre-allocate large arrays of values.
-}
-
-ec_scalar::ec_scalar(uint64_t value)
-{
-    *this = value;
+    // Avoid initializing secret pointer by default.
+    // Improves performance when pre-allocating large sets of ec_scalar.
 }
 
 ec_scalar::ec_scalar(const ec_secret& secret)
@@ -54,21 +51,14 @@ ec_scalar::ec_scalar(ec_scalar&& scalar)
     *this = std::move(scalar);
 }
 
+ec_scalar::ec_scalar(uint64_t value)
+{
+    *this = value;
+}
+
+
 // Operators.
 // ----------------------------------------------------------------------------
-
-ec_scalar& ec_scalar::operator=(uint64_t value)
-{
-    secret_.reset(new ec_secret);
-    static_assert(ec_secret_size == 32, "invalid size for ec_secret");
-    auto last_int_iterator = secret_->end() - 8;
-    // Fill first 24 bytes with zeroes
-    std::fill(secret_->begin(), last_int_iterator, 0);
-    // Write last 8 bytes with our uint64_t
-    auto serial = bc::system::make_unsafe_serializer(last_int_iterator);
-    serial.write_8_bytes_big_endian(value);
-    return *this;
-}
 
 ec_scalar& ec_scalar::operator=(const ec_secret& secret)
 {
@@ -78,12 +68,7 @@ ec_scalar& ec_scalar::operator=(const ec_secret& secret)
 
 ec_scalar& ec_scalar::operator=(const ec_scalar& scalar)
 {
-    if (!scalar)
-    {
-        secret_.reset();
-        return *this;
-    }
-    secret_.reset(new ec_secret(scalar.secret()));
+    scalar ? secret_.reset(new ec_secret(scalar.secret())) : secret_.reset();
     return *this;
 }
 
@@ -93,61 +78,63 @@ ec_scalar& ec_scalar::operator=(ec_scalar&& scalar)
     return *this;
 }
 
-ec_scalar ec_scalar::operator-() const
+// Canonical conversion from 64 bit unsigned integer is defined by OpenSSL.
+ec_scalar& ec_scalar::operator=(uint64_t value)
 {
-    if (!(*this))
-        return *this;
+    static constexpr auto value_size = sizeof(uint64_t);
+    static_assert(std::tuple_size<ec_secret>::value >= value_size, "overflow");
 
-    auto negation = *this;
-    BITCOIN_ASSERT(negation.secret_);
-    if (!ec_negate(*negation.secret_))
+    secret_.reset(new ec_secret);
+    auto value_iterator = secret_->end() - value_size;
+
+    // Zeroize up to last value_size bytes.
+    std::fill(secret_->begin(), value_iterator, 0);
+
+    // Write last value_size bytes with value.
+    auto serial = bc::system::make_unsafe_serializer(value_iterator);
+    serial.write_8_bytes_big_endian(value);
+    return *this;
+}
+
+ec_scalar ec_scalar::operator-()
+{
+    if (!(*this) || !ec_negate(*secret_))
         return {};
 
-    return negation;
+    return *this;
 }
 
 ec_scalar& ec_scalar::operator+=(const ec_scalar& scalar)
 {
-    if (!(*this))
-        return *this;
+    if (!(*this) || !scalar || !ec_add(*secret_, scalar))
+        secret_.reset();
 
-    *this = *this + scalar;
     return *this;
 }
 
 ec_scalar& ec_scalar::operator-=(const ec_scalar& scalar)
 {
-    if (!(*this))
-        return *this;
+    // TODO: any way to avoid copy (cannot change const parameter)?
+    auto copy = scalar;
 
-    *this = *this - scalar;
+    if (!(*this) || !scalar || !(ec_add(*secret_, -copy)))
+        secret_.reset();
+
     return *this;
 }
 
-ec_scalar::operator bool() const
+ec_scalar& ec_scalar::operator*=(const ec_scalar& scalar)
 {
-    // Caller must make both test against zero when that is required.
-    // Overloading bool with valid and non-zero would be very non-intuitive.
-    return static_cast<bool>(secret_);
-}
+    if (!(*this) || !scalar || !ec_multiply(*secret_, scalar))
+        secret_.reset();
 
-ec_scalar::operator const ec_secret&() const
-{
-    BITCOIN_ASSERT(secret_);
-    return *secret_;
-}
-
-const ec_secret& ec_scalar::secret() const
-{
-    BITCOIN_ASSERT(secret_);
-    return *secret_;
+    return *this;
 }
 
 bool operator==(const ec_scalar& left, const ec_scalar& right)
 {
-    // Compare arrays from left and right in reverse order since
-    // scalars are encoded in big endian format.
-    // The beginning bytes will be only zeroes for small scalars.
+    // Compare arrays from left and right in reverse order since scalars are
+    // encoded in big endian format, with leading bytes zero for small scalars.
     return left && right &&
         std::equal(left.secret().rbegin(), left.secret().rend(),
             right.secret().rbegin());
@@ -158,42 +145,65 @@ bool operator!=(const ec_scalar& left, const ec_scalar& right)
     return !(left == right);
 }
 
-ec_scalar operator+(ec_scalar left, const ec_scalar& right)
+ec_scalar operator+(const ec_scalar& left, const ec_scalar& right)
 {
     if (!left || !right)
         return {};
 
-    BITCOIN_ASSERT(left.secret_);
-    BITCOIN_ASSERT(right.secret_);
-    if (!ec_add(*left.secret_, *right.secret_))
-        return {};
+    // TODO: any way to avoid copy (cannot change const parameter)?
+    auto copy = left;
 
-    return left;
+    return copy += right;
 }
 
-ec_scalar operator-(ec_scalar left, const ec_scalar& right)
+ec_scalar operator-(const ec_scalar& left, const ec_scalar& right)
 {
     if (!left || !right)
         return {};
 
-    const auto negative_right = -right;
-    if (!negative_right)
-        return {};
+    // TODO: any way to avoid copies (cannot change const parameters)?
+    auto left_copy = left;
+    auto right_copy = right;
 
-    return left + negative_right;
+    return left_copy += -right_copy;
 }
 
-ec_scalar operator*(ec_scalar left, const ec_scalar& right)
+ec_scalar operator*(const ec_scalar& left, const ec_scalar& right)
 {
     if (!left || !right)
         return {};
 
-    BITCOIN_ASSERT(left.secret_);
-    BITCOIN_ASSERT(right.secret_);
-    if (!ec_multiply(*left.secret_, *right.secret_))
-        return {};
+    // TODO: any way to avoid copy (cannot change const parameter)?
+    auto copy = left;
 
-    return left;
+    return copy *= right;
+}
+
+// Cast operators.
+// ----------------------------------------------------------------------------
+
+ec_scalar::operator bool() const
+{
+    // Caller must make both test against zero when that is required.
+    // Overloading bool with valid and non-zero would be very non-intuitive.
+    return static_cast<bool>(secret_);
+}
+
+ec_scalar::operator const ec_secret&() const
+{
+    // Operation results or the object must be tested by the caller.
+    BITCOIN_ASSERT(secret_);
+    return *secret_;
+}
+
+// Accessors.
+// ----------------------------------------------------------------------------
+
+const ec_secret& ec_scalar::secret() const
+{
+    // Operation results or the object must be tested by the caller.
+    BITCOIN_ASSERT(secret_);
+    return *secret_;
 }
 
 } // namespace system


### PR DESCRIPTION
* Removes assertions that are provably unreachable.
* Eliminates use of the `new` operator.
* Eliminates unused type (`using`) definition.
* Reorganizes and comments method order more closely to lib conventions.
* Expands to full unit test coverage.
* Changes the negation operator to non-`const` (as it modifies the operand).
* Changes the binary math operators so that they retain expected `const`-ness (operands should not be modified).

For optimal performance the binary math operators `+`, `-` and `*` should be avoided as they create copies, due to the nature of the libsecp256k1 functions.

For optimal performance subtraction assignment `-=` should be avoided, as there is no subtraction function in libsecp256k1, resulting in a copy to avoid `const` operand modification.

The math assignment operators `+=` and `*=` are optimal. If one desires optimal subtraction then the following format should be used: `a += -b`, resulting in modification of both `a` and `b`.