### PR TITLE
Remove brew update from .yml where not required.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_install:
     - if [[ $TRAVIS_OS_NAME == linux   ]]; then LINUX=true; fi
 
     # Update homebrew.
-    - if [[ $OSX   && $CLANG             ]]; then brew update; fi
+    - if [[ $OSX   && $CLANG && $DYNAMIC ]]; then brew update; fi
 
 install:
 


### PR DESCRIPTION
This fixes a build break triggered by `brew update` but caused by a change to the underlying Travis platform. The update isn't required in the static macOS build.