### PR TITLE
Fixes electrum mnemonic validation by requiring the initial entropy.

### DIFF
--- a/include/bitcoin/system/wallet/electrum.hpp
+++ b/include/bitcoin/system/wallet/electrum.hpp
@@ -86,6 +86,7 @@ BC_API word_list create_mnemonic(const data_chunk& entropy,
  * words must have been created using electrum encoding.
  */
 BC_API bool validate_mnemonic(const word_list& mnemonic,
+    const data_chunk& entropy,
     const dictionary& lexicon,
     seed prefix=electrum::seed::standard);
 
@@ -93,6 +94,7 @@ BC_API bool validate_mnemonic(const word_list& mnemonic,
  * Checks that a mnemonic is valid in at least one of the provided languages.
  */
 BC_API bool validate_mnemonic(const word_list& mnemonic,
+    const data_chunk& entropy,
     const dictionary_list& lexicons=bc::system::wallet::language::electrum::all,
     seed prefix=electrum::seed::standard);
 

--- a/test/wallet/electrum.cpp
+++ b/test/wallet/electrum.cpp
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__no_dictionary__valid)
     const auto mnemonic = electrum::create_mnemonic(entropy);
     BOOST_REQUIRE(!mnemonic.empty());
     BOOST_REQUIRE_EQUAL(join(mnemonic), "giggle crush argue inflict wear defy combine evolve tiger spatial crumble fury");
-    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic));
+    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, entropy));
 }
 
 BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__en_dictionary__valid)
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__en_dictionary__valid)
     const auto mnemonic = electrum::create_mnemonic(entropy, language::electrum::en);
     BOOST_REQUIRE(!mnemonic.empty());
     BOOST_REQUIRE_EQUAL(join(mnemonic), "giggle crush argue inflict wear defy combine evolve tiger spatial crumble fury");
-    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::electrum::en));
+    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, entropy, language::electrum::en));
 }
 
 BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__en_dictionary_prefix__valid)
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__en_dictionary_prefix__valid)
     const auto mnemonic = electrum::create_mnemonic(entropy, language::electrum::en, electrum::seed::standard);
     BOOST_REQUIRE(!mnemonic.empty());
     BOOST_REQUIRE_EQUAL(join(mnemonic), "crawl consider laptop bonus stove chase earn battle feed town scatter radio");
-    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::electrum::en, electrum::seed::standard));
+    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, entropy, language::electrum::en, electrum::seed::standard));
 }
 
 // This test conforms to an electrum test.
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__ja_dictionary_prefix__valid)
     data_chunk entropy;
     decode_base16(entropy, "05b251d0b0f32da46966cd6e16ca740d6d"); // 1938439226660562861250521787963972783469
     const auto mnemonic = electrum::create_mnemonic(entropy, language::electrum::ja, electrum::seed::standard);
-    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::electrum::ja, electrum::seed::standard));
+    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, entropy, language::electrum::ja, electrum::seed::standard));
     const auto seed = electrum::decode_mnemonic(mnemonic);
     BOOST_REQUIRE_EQUAL(encode_base16(seed), "d3eaf0e44ddae3a5769cb08a26918e8b308258bcb057bb704c6f69713245c0b35cb92c03df9c9ece5eff826091b4e74041e010b701d44d610976ce8bfb66a8ad");
 
@@ -163,7 +163,6 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__ja_dictionary_prefix__valid)
 BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__en_dictionary_prefix_witness__valid)
 {
     const auto mnemonic = split("wild father tree among universe such mobile favorite target dynamic credit identify");
-    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::electrum::en, electrum::seed::witness));
     const auto seed = electrum::decode_mnemonic(mnemonic);
     BOOST_REQUIRE_EQUAL(encode_base16(seed), "aac2a6302e48577ab4b46f23dbae0774e2e62c796f797d0a1b5faeb528301e3064342dafb79069e7c4c6b8c38ae11d7a973bec0d4f70626f8cc5184a8d0b0756");
 }
@@ -174,7 +173,6 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__en_dictionary_prefix_witness_wit
 {
     const auto mnemonic = split("wild father tree among universe such mobile favorite target dynamic credit identify");
     const auto passphrase = "Did you ever hear the tragedy of Darth Plagueis the Wise?";
-    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::electrum::en, electrum::seed::witness));
     const auto seed = electrum::decode_mnemonic(mnemonic, passphrase);
     BOOST_REQUIRE_EQUAL(encode_base16(seed), "4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f");
 }
@@ -188,7 +186,7 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__es_dictionary_prefix__valid)
     data_chunk entropy;
     decode_base16(entropy, "0a0fecede9bf8a975eb6b4ef75bb79a04f"); // 3423992296655289706780599506247192518735
     const auto mnemonic = electrum::create_mnemonic(entropy, language::electrum::es);
-    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::electrum::es));
+    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, entropy, language::electrum::es));
     const auto seed = electrum::decode_mnemonic(mnemonic);
     BOOST_REQUIRE_EQUAL(encode_base16(seed), "18bffd573a960cc775bbd80ed60b7dc00bc8796a186edebe7fc7cf1f316da0fe937852a969c5c79ded8255cdf54409537a16339fbe33fb9161af793ea47faa7a");
 }
@@ -205,7 +203,7 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__es_dictionary_prefix_with_passph
     data_chunk entropy;
     decode_base16(entropy, "0a0fecede9bf8a975eb6b4ef75bb79a04f"); // 3423992296655289706780599506247192518735
     const auto mnemonic = electrum::create_mnemonic(entropy, language::electrum::es);
-    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::electrum::es));
+    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, entropy, language::electrum::es));
     const auto seed = electrum::decode_mnemonic(mnemonic, passphrase);
     BOOST_REQUIRE_EQUAL(encode_base16(seed), "363dec0e575b887cfccebee4c84fca5a3a6bed9d0e099c061fa6b85020b031f8fe3636d9af187bf432d451273c625e20f24f651ada41aae2c4ea62d87e9fa44c");
 }
@@ -219,7 +217,7 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__es_dictionary_prefix_witness__va
     data_chunk entropy;
     decode_base16(entropy, "01514c6f795e3bfdaca034e7ac2ed60275"); // 448346710104003081119421156750490206837
     const auto mnemonic = electrum::create_mnemonic(entropy, language::electrum::es, electrum::seed::witness);
-    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::electrum::es, electrum::seed::witness));
+    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, entropy, language::electrum::es, electrum::seed::witness));
     const auto seed = electrum::decode_mnemonic(mnemonic);
     BOOST_REQUIRE_EQUAL(encode_base16(seed), "001ebce6bfde5851f28a0d44aae5ae0c762b600daf3b33fc8fc630aee0d207646b6f98b18e17dfe3be0a5efe2753c7cdad95860adbbb62cecad4dedb88e02a64");
 }
@@ -237,7 +235,7 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__es_dictionary_prefix_witness_wit
     data_chunk entropy;
     decode_base16(entropy, "0a1f92ec9adfcdcadd2c955a8f2a5d47d0"); // 3444792611339130545499611089352232093648
     const auto mnemonic = electrum::create_mnemonic(entropy, language::electrum::es, electrum::seed::witness);
-    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::electrum::es, electrum::seed::witness));
+    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, entropy, language::electrum::es, electrum::seed::witness));
     const auto seed = electrum::decode_mnemonic(mnemonic, passphrase);
     BOOST_REQUIRE_EQUAL(encode_base16(seed), "c274665e5453c72f82b8444e293e048d700c59bf000cacfba597629d202dcf3aab1cf9c00ba8d3456b7943428541fed714d01d8a0a4028fc3a9bb33d981cb49f");
 }
@@ -249,7 +247,7 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__es_dictionary_prefix_standard__v
     const auto mnemonic = electrum::create_mnemonic(entropy, language::electrum::es, electrum::seed::standard);
     BOOST_REQUIRE(!mnemonic.empty());
     BOOST_REQUIRE_EQUAL(join(mnemonic), "gráfico codo ámbar insecto verbo cráter celoso entrar tarjeta sala coco frito");
-    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::electrum::es, electrum::seed::standard));
+    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, entropy, language::electrum::es, electrum::seed::standard));
 }
 
 BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__large_entropy_1__valid)
@@ -259,7 +257,7 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__large_entropy_1__valid)
     const auto mnemonic = electrum::create_mnemonic(entropy);
     BOOST_REQUIRE(!mnemonic.empty());
     BOOST_REQUIRE_EQUAL(join(mnemonic), "icon person grape only cash addict fringe disease luggage worry consider hover dignity wood street deny purpose shiver network chaos pole since shoe climb");
-    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::electrum::en, electrum::seed::standard));
+    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, entropy, language::electrum::en, electrum::seed::standard));
 }
 
 BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__large_entropy_2__valid)
@@ -269,7 +267,7 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__large_entropy_2__valid)
     const auto mnemonic = electrum::create_mnemonic(entropy);
     BOOST_REQUIRE(!mnemonic.empty());
     BOOST_REQUIRE_EQUAL(join(mnemonic), "divide february web hire limb run reject nuclear army zone brick below public ladder deer below again cluster divorce ketchup aerobic flee lonely absent");
-    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::electrum::en, electrum::seed::standard));
+    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, entropy, language::electrum::en, electrum::seed::standard));
 }
 
 BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__incorrent_mnemonic__invalid)
@@ -279,7 +277,7 @@ BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__incorrent_mnemonic__invalid)
     auto mnemonic = electrum::create_mnemonic(entropy);
     BOOST_REQUIRE(!mnemonic.empty());
     mnemonic[0] = "invalid";
-    BOOST_REQUIRE(!electrum::validate_mnemonic(mnemonic, language::electrum::en, electrum::seed::standard));
+    BOOST_REQUIRE(!electrum::validate_mnemonic(mnemonic, entropy, language::electrum::en, electrum::seed::standard));
 }
 
 #endif


### PR DESCRIPTION
Validation is now as follows: Provided a word list and a starting entropy value, it is possible to create a new mnemonic, which should match the provided word list.

There are a couple electrum test cases that do not provide the original entropy, so we don't validate those.  Many more electrum test cases do provide the entropy, so those are now properly validated.