### PR TITLE
Enable builds with c++20 and boost 1.76

### DIFF
--- a/include/bitcoin/system/compat.hpp
+++ b/include/bitcoin/system/compat.hpp
@@ -19,6 +19,7 @@
 #ifndef LIBBITCOIN_SYSTEM_COMPAT_HPP
 #define LIBBITCOIN_SYSTEM_COMPAT_HPP
 
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 

--- a/src/wallet/ec_private.cpp
+++ b/src/wallet/ec_private.cpp
@@ -235,7 +235,7 @@ bool ec_private::operator<(const ec_private& other) const
 bool ec_private::operator==(const ec_private& other) const
 {
     return compress_ == other.compress_ && version_ == other.version_ &&
-        *static_cast<const ec_scalar*>(this) == other;
+        *static_cast<const ec_scalar*>(this) == static_cast<const ec_scalar>(other);
 }
 
 bool ec_private::operator!=(const ec_private& other) const

--- a/test/unicode/unicode.cpp
+++ b/test/unicode/unicode.cpp
@@ -493,7 +493,9 @@ BOOST_AUTO_TEST_CASE(unicode__to_utf16_array__ascii__expected)
     uint8_t truncated;
     const auto size = to_utf16(truncated, utf16, sizeof(utf16), utf8.c_str(), (int)utf8.size());
 
-    BOOST_REQUIRE_EQUAL(utf16, expected_utf16.c_str());
+    // Only one of the two following checks are required
+    BOOST_REQUIRE(utf16 == expected_utf16);
+    BOOST_REQUIRE_EQUAL(wcscmp(utf16, expected_utf16.c_str()), 0);
     BOOST_REQUIRE_EQUAL(size, expected_utf16.size());
     BOOST_REQUIRE_EQUAL(truncated, 0u);
 }
@@ -511,7 +513,9 @@ BOOST_AUTO_TEST_CASE(unicode__to_utf16_array__non_ascii__expected)
     uint8_t truncated;
     const auto size = to_utf16(truncated, utf16, sizeof(utf16), utf8.c_str(), (int)utf8.size());
 
-    BOOST_REQUIRE_EQUAL(utf16, expected_utf16.c_str());
+    // Only one of the two following checks are required
+    BOOST_REQUIRE(utf16 == expected_utf16);
+    BOOST_REQUIRE_EQUAL(wcscmp(utf16, expected_utf16.c_str()), 0);
     BOOST_REQUIRE_EQUAL(size, expected_utf16.size());
     BOOST_REQUIRE_EQUAL(truncated, 0u);
 }
@@ -539,8 +543,8 @@ BOOST_AUTO_TEST_CASE(unicode__to_utf16_array__non_ascii_truncation1__expected)
     uint8_t truncated;
     const auto size = to_utf16(truncated, utf16, sizeof(utf16), utf8.c_str(), (int)utf8.size());
 
-    BOOST_REQUIRE_EQUAL(truncated, expected_truncated);
-    BOOST_REQUIRE_EQUAL(utf16, expected_utf16.c_str());
+    BOOST_REQUIRE(truncated == expected_truncated);
+    BOOST_REQUIRE(utf16 == expected_utf16);
     BOOST_REQUIRE_EQUAL(size, expected_utf16.size());
 }
 
@@ -567,8 +571,8 @@ BOOST_AUTO_TEST_CASE(unicode__to_utf16_array__non_ascii_truncation2__expected)
     uint8_t truncated;
     const auto size = to_utf16(truncated, utf16, sizeof(utf16), utf8.c_str(), (int)utf8.size());
 
-    BOOST_REQUIRE_EQUAL(truncated, expected_truncated);
-    BOOST_REQUIRE_EQUAL(utf16, expected_utf16.c_str());
+    BOOST_REQUIRE(truncated == expected_truncated);
+    BOOST_REQUIRE(utf16 == expected_utf16);
     BOOST_REQUIRE_EQUAL(size, expected_utf16.size());
 }
 


### PR DESCRIPTION
I am planning on using `system` with braidpool, locally I am using boost 1.76 and gcc/c++20.

To be sure `system` worked with those, I tried to run this locally and had to make a few changes for the tests to pass. These changes are backwards compatible.

Required only very few changes, mostly in unicode tests.