### PR TITLE
Add github actions for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,136 @@
+name: Run tests
+
+on:
+  push:
+    branches:
+      - $default-branch
+      - 'ci/github-actions'
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.config.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+              name: "Ubuntu gcc static",
+              os: ubuntu-latest,
+              cc: "gcc-10",
+              cxx: "g++-10",
+              link: "--disable-shared",
+              ndebug: "",
+              cflags: "-Og -g --coverage",
+              cxxflags: "-Og -g --coverage",
+            }
+          - {
+              name: "Ubuntu gcc dynamic",
+              os: ubuntu-latest,
+              cc: "gcc-10",
+              cxx: "g++-10",
+              link: "--disable-static",
+              ndebug: "",
+              cflags: "-Os",
+              cxxflags: "-Os",
+            }
+          - {
+              name: "Ubuntu clang static",
+              os: ubuntu-latest,
+              cc: "clang",
+              cxx: "clang++",
+              link: "--disable-shared",
+              ndebug: "",
+              cflags: "-Os",
+              cxxflags: "-Os",
+            }
+          - {
+              name: "Ubuntu clang dynamic",
+              os: ubuntu-latest,
+              cc: "clang",
+              cxx: "clang++",
+              link: "--disable-static",
+              ndebug: "--disable-ndebug",
+              cflags: "-Os",
+              cxxflags: "-Os",
+            }
+          - {
+              name: "macOs clang static",
+              os: macOs-latest,
+              cc: "clang",
+              cxx: "clang++",
+              link: "--disable-shared",
+              ndebug: "",
+              cflags: "",
+              cxxflags: "",
+            }
+          # TODO: rpath changes introduced as part of SIP in OSX 10.5+ break "macOs clang dynamic".
+          # - {
+          #     name: "macOs clang dynamic",
+          #     os: macOs-latest,
+          #     cc: "clang",
+          #     cxx: "clang++",
+          #     link: "--disable-static",
+          #     enable_rpath: "--enable-rpath",
+          #     ndebug: "",
+          #     cflags: "",
+          #     cxxflags: "",
+          #   }
+
+    env:
+      CC: ${{ matrix.config.cc }}
+      CXX: ${{ matrix.config.cxx }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install build essentials (linux)
+      if: runner.os == 'Linux'
+      run:  |
+        sudo apt-get update
+        sudo apt-get install build-essential autoconf automake libtool pkg-config git
+
+    - name: Install build essentials (macos)
+      if: runner.os == 'macOs'
+      run: |
+        brew install automake
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      id: dependencies-cache
+      with:
+        path: |
+          ${{ github.workspace }}/dependencies/
+          ${{ github.workspace }}/build/
+        key: ${{ runner.os }}-${{ matrix.config.os }}-${{ matrix.config.cc }}-${{ matrix.config.link }}-${{ hashFiles('install.sh') }}
+
+    - name: Build target without cache
+      if: steps.dependencies-cache.outputs.cache-hit != 'true'
+      run: >-
+        ./install.sh
+        --enable-isystem
+        --with-icu
+        --build-icu
+        --build-boost
+        ${{ matrix.config.link }}
+        --build-dir=${{github.workspace}}/build/
+        --prefix=${{github.workspace}}/dependencies/
+        CFLAGS='${{ matrix.config.cflags }}'
+        CXXFLAGS='${{ matrix.config.cxxflags }}'
+
+
+    - name: Build target with cache
+      if: steps.dependencies-cache.outputs.cache-hit == 'true'
+      run: >-
+        ./install.sh
+        --enable-isystem
+        --with-icu
+        --with-boost=${{github.workspace}}/dependencies/
+        ${{ matrix.config.link }}
+        --build-dir=${{github.workspace}}/build/
+        --prefix=${{github.workspace}}/dependencies/
+        CFLAGS='${{ matrix.config.cflags }}'
+        CXXFLAGS='${{ matrix.config.cxxflags }}'

--- a/install.sh
+++ b/install.sh
@@ -731,6 +731,9 @@ build_from_travis()
     if [[ $TRAVIS == true ]]; then
         build_from_local "Local $TRAVIS_REPO_SLUG" "$JOBS" "${OPTIONS[@]}" "$@"
         make_tests "$JOBS"
+    elif [[ $CI == true ]]; then
+        build_from_local "Local $GITHUB_WORKSPACE" "$JOBS" "${OPTIONS[@]}" "$@"
+        make_tests "$JOBS"
     else
         build_from_github "$ACCOUNT" "$REPO" "$BRANCH" "$JOBS" "${OPTIONS[@]}" "$@"
         push_directory "$BUILD_DIR"

--- a/libbitcoin-system-test_runner.sh
+++ b/libbitcoin-system-test_runner.sh
@@ -18,4 +18,10 @@ BOOST_UNIT_TEST_OPTIONS=\
 
 # Run tests.
 #==============================================================================
-./test/libbitcoin-system-test ${BOOST_UNIT_TEST_OPTIONS} > test.log
+
+# If running in github, send errors to std output
+if [[ $CI == true ]]; then
+    ./test/libbitcoin-system-test ${BOOST_UNIT_TEST_OPTIONS}
+else
+    ./test/libbitcoin-system-test ${BOOST_UNIT_TEST_OPTIONS} > test.log
+fi


### PR DESCRIPTION
Add support for github actions to run tests. 

Results from the latest run are here: https://github.com/pool2win/libbitcoin-system/actions/runs/1332074390. This run used cached depdencies, and the build time is around 17m.

Currently works for all the same combinations on Travis, apart from macOs dynamic link libs.

### Caching

The icu, boost builds are cached using github actions' "cache action". This results in reuse of the built dependencies for a branch and all the children branches.

### Runs for

The github CI action will run for PR's to `master` branch and for pushes to `ci/github-actions` branch - for debugging the ci setup.

### Next tasks

Need to figure out how to make the macOS shenanigans with rpath work. I can run things locally by using `install_name_tool`, but I need help to move it into libbitcoin-build or somewhere else where it can be automated for CI and user setups.