### PR TITLE
missing include for size_t on linux

### DIFF
--- a/include/bitcoin/system/wallet/dictionary.hpp
+++ b/include/bitcoin/system/wallet/dictionary.hpp
@@ -23,6 +23,7 @@
 #include <functional>
 #include <vector>
 #include <bitcoin/system/compat.hpp>
+#include <cstddef>
 
 namespace libbitcoin {
 namespace wallet {


### PR DESCRIPTION
bunch of compile errors for dictionary.hpp. Simple fix, missing header