### PR TITLE
Setup tx for signing using connect

### DIFF
--- a/builds/cmake/CMakeLists.txt
+++ b/builds/cmake/CMakeLists.txt
@@ -515,6 +515,7 @@ if (with-tests)
         "../../test/chain/script.hpp"
         "../../test/chain/stripper.cpp"
         "../../test/chain/transaction.cpp"
+        "../../test/chain/transaction_sign.cpp"
         "../../test/chain/witness.cpp"
         "../../test/chain/enums/opcode.cpp"
         "../../test/config/base16.cpp"

--- a/include/bitcoin/system/chain/transaction.hpp
+++ b/include/bitcoin/system/chain/transaction.hpp
@@ -145,8 +145,8 @@ public:
 
     // Signing (for use in wallets)
     // ------------------------------------------------------------------------
-    endorsements generate_signatures(const uint8_t input_index, const ec_secret private_key,
-				     const uint8_t flags, const context& state) const;
+    endorsements generate_signatures(const uint8_t input_index,
+        const context& state) const;
 
 protected:
     transaction(uint32_t version, const chain::inputs_cptr& inputs,

--- a/include/bitcoin/system/chain/transaction.hpp
+++ b/include/bitcoin/system/chain/transaction.hpp
@@ -19,6 +19,8 @@
 #ifndef LIBBITCOIN_SYSTEM_CHAIN_TRANSACTION_HPP
 #define LIBBITCOIN_SYSTEM_CHAIN_TRANSACTION_HPP
 
+#include "bitcoin/system/crypto/secp256k1.hpp"
+#include <cstdint>
 #include <istream>
 #include <memory>
 #include <vector>
@@ -30,6 +32,7 @@
 #include <bitcoin/system/error/error.hpp>
 #include <bitcoin/system/hash/hash.hpp>
 #include <bitcoin/system/stream/stream.hpp>
+#include <bitcoin/system/crypto/crypto.hpp>
 
 namespace libbitcoin {
 namespace system {
@@ -139,6 +142,11 @@ public:
     code check() const NOEXCEPT;
     code accept(const context& state) const NOEXCEPT;
     code connect(const context& state) const NOEXCEPT;
+
+    // Signing (for use in wallets)
+    // ------------------------------------------------------------------------
+    endorsements generate_signatures(const uint8_t input_index, const ec_secret private_key,
+				     const uint8_t flags, const context& state) const;
 
 protected:
     transaction(uint32_t version, const chain::inputs_cptr& inputs,

--- a/include/bitcoin/system/impl/machine/interpreter.ipp
+++ b/include/bitcoin/system/impl/machine/interpreter.ipp
@@ -1168,8 +1168,14 @@ op_check_multisig_verify() NOEXCEPT
             BC_POP_WARNING()
 
             // TODO: for signing mode - make key mutable and return above.
-            if (system::verify_signature(*key, hash, sig))
+            if (system::verify_signature(*key, hash, sig)){
+                if (state::sign_mode_){
+                    der_signature encoded_sig;
+                    encode_signature(encoded_sig, sig);
+                    state::generated_signatures_.emplace_back(encoded_sig);
+                }
                 ++endorsement;
+            }
         }
     }
 

--- a/include/bitcoin/system/impl/machine/program.ipp
+++ b/include/bitcoin/system/impl/machine/program.ipp
@@ -834,6 +834,13 @@ prepare(ec_signature& signature, const data_chunk&, hash_cache& cache,
     // Obtain the signature hash from subscript and sighash flags.
     signature_hash(cache, sub, flags);
 
+    if (sign_mode_) {
+        ec_secret secret_key;
+        std::copy_n(endorsement.begin(), 32, secret_key.begin());
+        if (system::sign(signature, secret_key, cache[flags])) {
+            return true;
+        }
+    }
     // Parse DER signature into an EC signature (bip66 sets strict).
     const auto bip66 = is_enabled(forks::bip66_rule);
     return parse_signature(signature, distinguished, bip66);

--- a/include/bitcoin/system/impl/machine/program.ipp
+++ b/include/bitcoin/system/impl/machine/program.ipp
@@ -801,15 +801,11 @@ prepare(ec_signature& signature, const ec_secret& secret_key, hash_digest& hash,
     if (!parse_endorsement(flags, distinguished, *endorsement))
         return false;
 
-    std::cerr << "Parsed endorsement: " << encode_base16(distinguished) << std::endl;
     // Obtain the signature hash from subscript and sighash flags.
     hash = signature_hash(*subscript({ endorsement }), flags);
 
-    std::cerr << "Signature hash: " << encode_base16(hash) << std::endl;
-
     if(sign_mode_){
         if (system::sign(signature, secret_key, hash)) {
-            std::cerr << "Signature: " << encode_base16(signature) << std::endl;
             return true;
         }
     }

--- a/include/bitcoin/system/machine/interpreter.hpp
+++ b/include/bitcoin/system/machine/interpreter.hpp
@@ -157,7 +157,8 @@ protected:
     inline error::op_error_t op_check_sequence_verify() const NOEXCEPT;
 
 private:
-  static void collect_signatures(endorsements& target, const endorsements& signatures);
+  static void collect_signatures(endorsements& target, const endorsements& signatures_to_collect);
+  static void collect_signing_keys(data_stack& target, const data_stack& keys_to_collect);
 };
 } // namespace machine
 } // namespace system

--- a/include/bitcoin/system/machine/interpreter.hpp
+++ b/include/bitcoin/system/machine/interpreter.hpp
@@ -19,6 +19,7 @@
 #ifndef LIBBITCOIN_SYSTEM_MACHINE_INTERPRETER_HPP
 #define LIBBITCOIN_SYSTEM_MACHINE_INTERPRETER_HPP
 
+#include "bitcoin/system/crypto/secp256k1.hpp"
 #include <bitcoin/system/data/data.hpp>
 #include <bitcoin/system/define.hpp>
 #include <bitcoin/system/error/error.hpp>
@@ -49,11 +50,19 @@ public:
 
     /// Connect tx.input[#].script to tx.input[#].prevout.script.
     static code connect(const context& state, const transaction& tx,
-        uint32_t index) NOEXCEPT;
+			uint32_t index) NOEXCEPT;
 
-    /// Connect tx.input[*].script to tx.input[*].prevout.script.
     static code connect(const context& state, const transaction& tx,
-        const input_iterator& it) NOEXCEPT;
+			const input_iterator& it) NOEXCEPT;
+
+  /// Connect tx.input[*].script to tx.input[*].prevout.script.
+    static code connect(const context& state, const transaction& tx,
+			const input_iterator& it, const bool sign_mode,
+			endorsements& signatures) NOEXCEPT;
+
+    static code connect_for_signing(const context& state, const transaction& tx,
+				    uint32_t index,
+				    endorsements& signatures) NOEXCEPT;
 
 protected:
     /// Operation disatch.
@@ -146,8 +155,10 @@ protected:
     inline error::op_error_t op_check_multisig() NOEXCEPT;
     inline error::op_error_t op_check_locktime_verify() const NOEXCEPT;
     inline error::op_error_t op_check_sequence_verify() const NOEXCEPT;
-};
 
+private:
+  static void collect_signatures(endorsements& target, const endorsements& signatures);
+};
 } // namespace machine
 } // namespace system
 } // namespace libbitcoin

--- a/include/bitcoin/system/machine/program.hpp
+++ b/include/bitcoin/system/machine/program.hpp
@@ -20,6 +20,7 @@
 #define LIBBITCOIN_SYSTEM_MACHINE_PROGRAM_HPP
 
 #include "bitcoin/system/crypto/secp256k1.hpp"
+#include "bitcoin/system/data/data_chunk.hpp"
 #include <unordered_map>
 #include <vector>
 #include <bitcoin/system/chain/chain.hpp>
@@ -32,6 +33,8 @@
 namespace libbitcoin {
 namespace system {
 namespace machine {
+
+typedef std::vector<der_signature> der_signatures;
 
 /// A set of three stacks (primary, alternate, conditional) for script state.
 /// Primary stack is optimized by peekable, swappable, and eraseable elements.
@@ -69,7 +72,8 @@ public:
     /// Transaction must pop top input stack element (bip16).
     inline const data_chunk& pop() NOEXCEPT;
 
-    inline endorsements generated_signatures() const NOEXCEPT;
+    inline der_signatures& generated_signatures() NOEXCEPT;
+    inline data_stack& signing_keys() NOEXCEPT;
 
 protected:
     INLINE static bool equal_chunks(const stack_variant& left,
@@ -162,13 +166,19 @@ protected:
         const chunk_xptrs& endorsements) const NOEXCEPT;
 
     /// Prepare signature (enables generalized signing).
-    inline bool prepare(ec_signature& signature, const data_chunk& key,
+    inline bool prepare(ec_signature& signature, const ec_secret& key,
         hash_digest& hash, const chunk_xptr& endorsement) const NOEXCEPT;
 
     /// Prepare signature, with caching for multisig with same flags.
     inline bool prepare(ec_signature& signature, const data_chunk& key,
         hash_cache& cache, uint8_t& flags, const data_chunk& endorsement,
         const chain::script& sub) const NOEXCEPT;
+
+    // Signing mode
+    const bool sign_mode_;
+
+    der_signatures generated_signatures_;
+    data_stack signing_keys_;
 
 private:
     using primary_stack = stack<Stack>;
@@ -211,12 +221,6 @@ private:
 
     // Condition stack optimization.
     size_t negative_condition_count_{};
-
-    // Signing mode
-    const bool sign_mode_;
-    // TODO[KP]: Turn this into a map of old endorsement -> new endorsement.
-    // Q[KP]: Should we introduce as `typedef for std::vector<signature> signatures`
-    endorsements generated_signatures_;
 };
 
 } // namespace machine

--- a/include/bitcoin/system/machine/program.hpp
+++ b/include/bitcoin/system/machine/program.hpp
@@ -19,6 +19,7 @@
 #ifndef LIBBITCOIN_SYSTEM_MACHINE_PROGRAM_HPP
 #define LIBBITCOIN_SYSTEM_MACHINE_PROGRAM_HPP
 
+#include "bitcoin/system/crypto/secp256k1.hpp"
 #include <unordered_map>
 #include <vector>
 #include <bitcoin/system/chain/chain.hpp>
@@ -46,27 +47,29 @@ public:
 
     /// Input script run (default/empty stack).
     inline program(const chain::transaction& transaction,
-        const input_iterator& input, uint32_t forks) NOEXCEPT;
+        const input_iterator& input, uint32_t forks,
+        const bool sign_mode=false) NOEXCEPT;
 
     /// Legacy p2sh or prevout script run (copied input stack).
     inline program(const program& other,
-        const chain::script::cptr& script) NOEXCEPT;
+		   const chain::script::cptr& script) NOEXCEPT;
 
     /// Legacy p2sh or prevout script run (moved input stack).
-    inline program(program&& other,
-        const chain::script::cptr& script) NOEXCEPT;
+    inline program(program&& other, const chain::script::cptr& script) NOEXCEPT;
 
     /// Witness script run (witness-initialized stack).
     inline program(const chain::transaction& transaction,
-        const input_iterator& input, const chain::script::cptr& script,
-        uint32_t forks, chain::script_version version,
-        const chunk_cptrs_ptr& stack) NOEXCEPT;
+	const input_iterator& input, const chain::script::cptr& script,
+	uint32_t forks, chain::script_version version,
+	const chunk_cptrs_ptr& stack, const bool sign_mode=false) NOEXCEPT;
 
     /// Program result.
     inline bool is_true(bool clean) const NOEXCEPT;
 
     /// Transaction must pop top input stack element (bip16).
     inline const data_chunk& pop() NOEXCEPT;
+
+    inline endorsements generated_signatures() const NOEXCEPT;
 
 protected:
     INLINE static bool equal_chunks(const stack_variant& left,
@@ -208,6 +211,12 @@ private:
 
     // Condition stack optimization.
     size_t negative_condition_count_{};
+
+    // Signing mode
+    const bool sign_mode_;
+    // TODO[KP]: Turn this into a map of old endorsement -> new endorsement.
+    // Q[KP]: Should we introduce as `typedef for std::vector<signature> signatures`
+    endorsements generated_signatures_;
 };
 
 } // namespace machine

--- a/src/chain/transaction.cpp
+++ b/src/chain/transaction.cpp
@@ -16,9 +16,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include "bitcoin/system/error/error_t.hpp"
+#include "bitcoin/system/error/transaction_error_t.hpp"
 #include <bitcoin/system/chain/transaction.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <iterator>
 #include <memory>
 #include <numeric>
@@ -1281,6 +1284,26 @@ code transaction::connect(const context& state) const NOEXCEPT
     }
 
     return error::transaction_success;
+}
+
+// Sign
+// ------------------------------------------------------------------------
+
+endorsements transaction::
+generate_signatures(const uint8_t input_index, const ec_secret private_key,
+    const uint8_t flags, const context& state) const
+{
+  /// turn sign_mode on
+  /// call connect
+  /// return the generated signatures returned from connect?
+  std::cerr << "In generate signatures" << std::endl;
+  endorsements signatures;
+  auto code = machine::interpreter<machine::contiguous_stack>::
+    connect_for_signing(state, *this, input_index, signatures);
+  if (code) {
+    return {};
+  }
+  return signatures;
 }
 
 // JSON value convertors.

--- a/src/chain/transaction.cpp
+++ b/src/chain/transaction.cpp
@@ -1290,8 +1290,7 @@ code transaction::connect(const context& state) const NOEXCEPT
 // ------------------------------------------------------------------------
 
 endorsements transaction::
-generate_signatures(const uint8_t input_index, const ec_secret private_key,
-    const uint8_t flags, const context& state) const
+generate_signatures(const uint8_t input_index, const context& state) const
 {
   /// turn sign_mode on
   /// call connect
@@ -1300,9 +1299,7 @@ generate_signatures(const uint8_t input_index, const ec_secret private_key,
   endorsements signatures;
   auto code = machine::interpreter<machine::contiguous_stack>::
     connect_for_signing(state, *this, input_index, signatures);
-  if (code) {
-    return {};
-  }
+  std::cerr << "error connecting for signatures " << code << std::endl;
   return signatures;
 }
 

--- a/src/chain/transaction.cpp
+++ b/src/chain/transaction.cpp
@@ -1299,7 +1299,6 @@ generate_signatures(const uint8_t input_index, const context& state) const
   endorsements signatures;
   auto code = machine::interpreter<machine::contiguous_stack>::
     connect_for_signing(state, *this, input_index, signatures);
-  std::cerr << "error connecting for signatures " << code << std::endl;
   return signatures;
 }
 

--- a/src/crypto/secp256k1.cpp
+++ b/src/crypto/secp256k1.cpp
@@ -369,6 +369,7 @@ bool parse_endorsement(uint8_t& sighash_flags, data_slice& der_signature,
 bool parse_signature(ec_signature& out, const data_slice& der_signature,
     bool strict) NOEXCEPT
 {
+  // KP - instead of parsing the signature
     if (der_signature.empty())
         return false;
 

--- a/test/chain/script.cpp
+++ b/test/chain/script.cpp
@@ -297,6 +297,18 @@ BOOST_AUTO_TEST_CASE(script__from_string__empty__success)
     BOOST_REQUIRE(instance.ops().empty());
 }
 
+BOOST_AUTO_TEST_CASE(script__from_string__p2pkh__success)
+{
+    const script instance("dup hash160 [abe507d92d415f688f3c22ca9689404df66edb5e] checksigverify");
+    BOOST_REQUIRE(instance.is_valid());
+
+    const auto& ops = instance.ops();
+    BOOST_REQUIRE(ops[0] == opcode::dup);
+    BOOST_REQUIRE(ops[1] == opcode::hash160);
+    BOOST_REQUIRE_EQUAL(ops[2].to_string(forks::no_rules), "[abe507d92d415f688f3c22ca9689404df66edb5e]");
+    BOOST_REQUIRE(ops[3] == opcode::checksigverify);
+}
+
 BOOST_AUTO_TEST_CASE(script__from_string__two_of_three_multisig__success)
 {
     const script instance(script_2_of_3_multisig);
@@ -644,6 +656,9 @@ BOOST_AUTO_TEST_CASE(script__verify__testnet_block_23428_multisig_tx__success)
     constexpr auto value = 100000000u;
     (*tx.inputs_ptr())[index]->prevout.reset(new prevout{ value, { base16_chunk("a9144aba54e2541475f91659ccdbb13ce0b490778c7f87"), false } });
     BOOST_REQUIRE_EQUAL(tx.connect({ forks }, index), error::script_success);
+    // KP
+    // tx.sign() essentially set flag and generate signature.
+    // program should have the flag if they are signing mode or not, but this is passed through from the interpreter construct
 }
 
 BOOST_AUTO_TEST_CASE(script__verify__block_290329_tx__success)

--- a/test/chain/transaction_sign.cpp
+++ b/test/chain/transaction_sign.cpp
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2011-2022 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "../test.hpp"
+#include <sstream>
+#include "bitcoin/system/chain/enums/coverage.hpp"
+#include "bitcoin/system/chain/enums/forks.hpp"
+#include "bitcoin/system/chain/enums/script_version.hpp"
+#include "bitcoin/system/chain/script.hpp"
+#include "bitcoin/system/chain/transaction.hpp"
+#include "bitcoin/system/crypto/secp256k1.hpp"
+#include "bitcoin/system/radix/base_16.hpp"
+#include "script.hpp"
+
+BOOST_AUTO_TEST_SUITE(transaction_sign_tests)
+
+using namespace system::chain;
+using namespace system::machine;
+
+// Test helpers.
+// -----------------------------------------------------------------------------
+
+class transaction_accessor
+  : public transaction
+{
+public:
+    using transaction::transaction;
+
+    code connect(const context& state) const NOEXCEPT
+    {
+        return transaction::connect(state);
+    }
+
+    code connect(const context& state, uint32_t index) const NOEXCEPT
+    {
+        return interpreter<contiguous_stack>::connect(state, *this, index);
+    }
+};
+
+transaction_accessor test_tx(const script_test& test)
+{
+    const script in{ test.input };
+    const script out{ test.output };
+
+    if (!in.is_valid() || !out.is_valid())
+        return {};
+
+    const transaction_accessor tx
+    {
+        test.version,
+        inputs
+        {
+            {
+                point{},
+                in,
+                test.input_sequence
+            }
+        },
+        outputs{},
+        test.locktime
+    };
+
+    tx.inputs_ptr()->front()->prevout.reset(new prevout{ 0u, out });
+    return tx;
+}
+
+std::string test_name(const script_test& test)
+{
+    std::stringstream out;
+    out << "input: \"" << test.input << "\" "
+        << "prevout: \"" << test.output << "\" "
+        << "("
+            << test.input_sequence << ", "
+            << test.locktime << ", "
+            << test.version
+        << ") "
+        << "name: " << test.description;
+    return out.str();
+}
+
+// The following tests are derived from the test/chain/transaction.cpp
+// create_endorsement tests
+
+BOOST_AUTO_TEST_CASE(transaction__sign_transaction__single_input_single_output__expected)
+{
+  // create a transaction with p2pkh output
+  // 1. Create a key pair
+  // 2. Create previous transaction
+  //    - Input: coinbase.
+  //    - Output: p2pkh of the pk above
+  // 3. Create spending transaction
+  //    - Input: previous tx, index 0;
+  //    - Output: p2pkh of the pk above
+  // Then sign the spending transaction using generate_signatures
+  //    - Pass secret key
+  //    - Input program is obtained by spending_transaction->input->script
+  //    - Prevout program is obtained by spending_transaction->input->prevout->script
+
+  // Seed: d31e623e6dff00d5c0fd3aff010b80cc63787a63cbd564cd
+  // key: b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de
+  // public_key: 02b59709bc5c29246bd94d48e90dde62442e97d1ccd9a2315b6303c82b07aa4412
+  // public_key hash: ca041a6aed6e8ab099cd75d65f8ef99e669a2d95
+    
+    const ec_secret secret_key = base16_array("b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de");
+    // ec_compressed public_point;
+    // const auto public_key = secret_to_public(public_point, secret_key);
+
+    const chain::transaction previous_transaction
+    {
+        1,
+        chain::inputs
+        {
+            chain::input
+            {
+                
+                // coinbase
+                chain::point{ null_hash, point::null_index },
+                chain::script{},
+                1
+            },
+        },
+        chain::outputs
+        {
+            chain::output
+            {
+                100,
+                chain::script{"dup hash160 [ca041a6aed6e8ab099cd75d65f8ef99e669a2d95] equalverify checksig"}
+            },
+        },
+        144
+    };
+
+    const chain::transaction spending_transaction
+    {
+        1,
+        chain::inputs
+        {
+            chain::input
+            {
+                
+                // coinbase
+                chain::point{ previous_transaction.hash(false), 0u },
+                // Use the private key instead of the public key.
+                // Use a dummy place holder signature
+                chain::script{"[000000000001] [b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de]"},
+                1
+            },
+        },
+        chain::outputs
+        {
+            chain::output
+            {
+                90, // leave 10 as fee, spend back to d01 key hash
+                chain::script{"dup hash160 [d01453c0b2e4abaa6589fd156da42e875c413539] equalverify checksig"}
+            },
+        },
+        144
+    };
+    
+    
+    BOOST_REQUIRE(previous_transaction.is_valid());
+    BOOST_REQUIRE(spending_transaction.is_valid());
+
+    const auto prevout_script = previous_transaction.outputs_ptr()->front()->script();
+
+    // std::cerr << " prevout a " << test_tx.inputs_ptr()->front()->prevout->script().to_string(forks::no_rules) << std::endl;
+
+    spending_transaction.inputs_ptr()->front()->prevout.reset(new prevout{0u, prevout_script});
+
+    // std::cerr << " prevout b " << test_tx.inputs_ptr()->front()->prevout->script().to_string(forks::no_rules) << std::endl;
+
+    // std::cerr << encode_base16(test_tx.to_data(false)) << std::endl;
+    // const ec_secret secret = base16_hash("ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333");
+    std::cerr << "Spending transaction inputs size:: " <<
+        spending_transaction.inputs_ptr()->size() << std::endl;
+    std::cerr << "Spending transaction input script:: " <<
+        spending_transaction.inputs_ptr()->front()->script().to_string(forks::no_rules) << std::endl;
+    std::cerr << "Spending transaction OUTPUT size:: " <<
+        spending_transaction.outputs_ptr()->size() << std::endl;
+    std::cerr << "Spending transaction OUTPUT script:: " <<
+        spending_transaction.outputs_ptr()->front()->script().to_string(forks::all_rules) << std::endl;
+    auto signatures = spending_transaction.generate_signatures(0u, secret_key, coverage::hash_all, {forks::no_rules,0});
+
+    // // const auto expected = base16_chunk("3045022100e428d3cc67a724cb6cfe8634aa299e58f189d9c46c02641e936c40cc16c7e8ed0220083949910fe999c21734a1f33e42fca15fb463ea2e08f0a1bccd952aacaadbb801");
+    // BOOST_REQUIRE_EQUAL(signatures.size(), 0);
+}
+
+
+// // bip143 test cases.
+// // ----------------------------------------------------------------------------
+
+// BOOST_AUTO_TEST_CASE(script__verify__bip143_native_p2wpkh_tx__success)
+// {
+//     const auto decoded_tx = base16_chunk("01000000000102fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac000247304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635711000000");
+//     const transaction_accessor tx(decoded_tx, true);
+//     BOOST_REQUIRE(tx.is_valid());
+//     BOOST_REQUIRE_EQUAL(tx.inputs_ptr()->size(), 2u);
+//     BOOST_REQUIRE((*tx.inputs_ptr())[0]->witness().stack().empty());
+//     BOOST_REQUIRE(!(*tx.inputs_ptr())[1]->witness().stack().empty());
+
+//     constexpr auto value0 = 625000000u;
+//     (*tx.inputs_ptr())[0]->prevout.reset(new prevout{ value0, { base16_chunk("2103c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432ac"), false } });
+
+//     constexpr auto value1 = 600000000u;
+//     (*tx.inputs_ptr())[1]->prevout.reset(new prevout{ value1, { base16_chunk("00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1"), false } });
+
+//     // ordinary P2PK (no rules required).
+//     BOOST_REQUIRE_EQUAL(tx.connect({ forks::no_rules }, 0), error::script_success);
+
+//     // P2WPKH witness program.
+//     BOOST_REQUIRE_EQUAL(tx.connect({ forks::bip141_rule | forks::bip143_rule }, 1), error::script_success);
+
+//     // Other scenarios:
+
+//     // extra rules (okay).
+//     BOOST_REQUIRE_EQUAL(tx.connect({ forks::bip141_rule | forks::bip143_rule }, 0), error::script_success);
+
+//     // missing bip143 (invalid sighash).
+//     BOOST_REQUIRE_EQUAL(tx.connect({ forks::bip141_rule }, 1), error::stack_false);
+
+//     // missing bip141 (witness not allowed).
+//     BOOST_REQUIRE_EQUAL(tx.connect({ forks::bip143_rule }, 1), error::unexpected_witness);
+
+//     // missing bip141 (witness not allowed).
+//     BOOST_REQUIRE_EQUAL(tx.connect({ forks::no_rules }, 1), error::unexpected_witness);
+// }
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/chain/transaction_sign.cpp
+++ b/test/chain/transaction_sign.cpp
@@ -104,7 +104,7 @@ std::string test_name(const script_test& test)
 // public_key hash: ca041a6aed6e8ab099cd75d65f8ef99e669a2d95
 BOOST_AUTO_TEST_CASE(transaction__generate_signatures__single_input_single_output__expected)
 {
-    const ec_secret secret_key = base16_array("b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de");
+    // const ec_secret secret_key = base16_array("b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de");
     const chain::transaction previous_transaction
     {
         1,
@@ -284,10 +284,6 @@ BOOST_AUTO_TEST_CASE(transaction__generate_signatures__multi_sig__expected)
     spending_transaction.inputs_ptr()->front()->prevout.reset(new prevout{0u, prevout_script});
     auto signatures = spending_transaction.generate_signatures(0u, {forks::no_rules,0});
 
-    std::cerr << signatures.size() << std::endl;
-    for (auto sig : signatures) {
-        std::cerr << "sig: " << sig << std::endl;
-    }
     BOOST_REQUIRE_EQUAL(encode_base16(signatures.at(0)), "3044022061ccdc51a4f1b7bd6e1d89b945336bd18aad0bce3f2e9657826487569b64d96502201a3d0e8e2bc70ce0fcd8358d177ec6d710b0a0ddd6c9586729a00aab5fe49ede");
     BOOST_REQUIRE_EQUAL(encode_base16(signatures.at(1)), "3044022010a3645d88dfa9d79e7ec90891fd306a082a855880a9fff5c47235eb4abb7c260220610d09672aead8e79e64da2c841b0a0f3579866aa73a2fc24e2d6935b798d1ea");
     BOOST_REQUIRE_EQUAL(encode_base16(signatures.at(2)), "3045022100c0675c34df1f678892d4babc44e5cd38bc6dd80e497a5860a276cd44961845a00220035369825776a15f81c2c163aa09dad00d1e0ba06a59e1868badac424f06ea4e");

--- a/test/chain/transaction_sign.cpp
+++ b/test/chain/transaction_sign.cpp
@@ -98,6 +98,10 @@ std::string test_name(const script_test& test)
 // The following tests are derived from the test/chain/transaction.cpp
 // create_endorsement tests
 
+// Seed: d31e623e6dff00d5c0fd3aff010b80cc63787a63cbd564cd
+// key: b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de
+// public_key: 02b59709bc5c29246bd94d48e90dde62442e97d1ccd9a2315b6303c82b07aa4412
+// public_key hash: ca041a6aed6e8ab099cd75d65f8ef99e669a2d95
 BOOST_AUTO_TEST_CASE(transaction__generate_signatures__single_input_single_output__expected)
 {
     const ec_secret secret_key = base16_array("b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de");
@@ -159,7 +163,7 @@ BOOST_AUTO_TEST_CASE(transaction__generate_signatures__single_input_single_outpu
     const auto prevout_script = previous_transaction.outputs_ptr()->front()->script();
 
     spending_transaction.inputs_ptr()->front()->prevout.reset(new prevout{0u, prevout_script});
-    auto signatures = spending_transaction.generate_signatures(0u, secret_key, coverage::hash_all, {forks::no_rules,0});
+    auto signatures = spending_transaction.generate_signatures(0u, {forks::no_rules,0});
 
     BOOST_REQUIRE_EQUAL(encode_base16(signatures.front()), "3044022052be662338ea349319271ff945f09b006a25e71aa6bdee421ef064d6a701af8102205a07aead4ab5b99f09ac69fd4352cbfeb52105b2dfc9f333a407925de7fdefb3");
 
@@ -173,7 +177,7 @@ BOOST_AUTO_TEST_CASE(transaction__generate_signatures__single_input_single_outpu
             {
                 // coinbase
                 chain::point{ previous_transaction.hash(false), 0u },
-                // The signature is the secret key with sighash flasg appended at the end [<secret_key><sighash_flags>]
+                // The signature is the secret key with sighash flags appended at the end [<secret_key><sighash_flags>]
                 chain::script{"[3044022052be662338ea349319271ff945f09b006a25e71aa6bdee421ef064d6a701af8102205a07aead4ab5b99f09ac69fd4352cbfeb52105b2dfc9f333a407925de7fdefb300] [02b59709bc5c29246bd94d48e90dde62442e97d1ccd9a2315b6303c82b07aa4412]"},
                 1
             },

--- a/test/chain/transaction_sign.cpp
+++ b/test/chain/transaction_sign.cpp
@@ -24,6 +24,8 @@
 #include "bitcoin/system/chain/script.hpp"
 #include "bitcoin/system/chain/transaction.hpp"
 #include "bitcoin/system/crypto/secp256k1.hpp"
+#include "bitcoin/system/error/op_error_t.hpp"
+#include "bitcoin/system/error/transaction_error_t.hpp"
 #include "bitcoin/system/radix/base_16.hpp"
 #include "script.hpp"
 
@@ -96,30 +98,9 @@ std::string test_name(const script_test& test)
 // The following tests are derived from the test/chain/transaction.cpp
 // create_endorsement tests
 
-BOOST_AUTO_TEST_CASE(transaction__sign_transaction__single_input_single_output__expected)
+BOOST_AUTO_TEST_CASE(transaction__generate_signatures__single_input_single_output__expected)
 {
-  // create a transaction with p2pkh output
-  // 1. Create a key pair
-  // 2. Create previous transaction
-  //    - Input: coinbase.
-  //    - Output: p2pkh of the pk above
-  // 3. Create spending transaction
-  //    - Input: previous tx, index 0;
-  //    - Output: p2pkh of the pk above
-  // Then sign the spending transaction using generate_signatures
-  //    - Pass secret key
-  //    - Input program is obtained by spending_transaction->input->script
-  //    - Prevout program is obtained by spending_transaction->input->prevout->script
-
-  // Seed: d31e623e6dff00d5c0fd3aff010b80cc63787a63cbd564cd
-  // key: b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de
-  // public_key: 02b59709bc5c29246bd94d48e90dde62442e97d1ccd9a2315b6303c82b07aa4412
-  // public_key hash: ca041a6aed6e8ab099cd75d65f8ef99e669a2d95
-    
     const ec_secret secret_key = base16_array("b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de");
-    // ec_compressed public_point;
-    // const auto public_key = secret_to_public(public_point, secret_key);
-
     const chain::transaction previous_transaction
     {
         1,
@@ -155,9 +136,8 @@ BOOST_AUTO_TEST_CASE(transaction__sign_transaction__single_input_single_output__
                 
                 // coinbase
                 chain::point{ previous_transaction.hash(false), 0u },
-                // Use the private key instead of the public key.
-                // Use a dummy place holder signature
-                chain::script{"[000000000001] [b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de]"},
+                // The signature is the secret key with sighash appended at the end [<secret_key><sighash_flags>]
+                chain::script{"[b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de00] [02b59709bc5c29246bd94d48e90dde62442e97d1ccd9a2315b6303c82b07aa4412]"},
                 1
             },
         },
@@ -178,67 +158,39 @@ BOOST_AUTO_TEST_CASE(transaction__sign_transaction__single_input_single_output__
 
     const auto prevout_script = previous_transaction.outputs_ptr()->front()->script();
 
-    // std::cerr << " prevout a " << test_tx.inputs_ptr()->front()->prevout->script().to_string(forks::no_rules) << std::endl;
-
     spending_transaction.inputs_ptr()->front()->prevout.reset(new prevout{0u, prevout_script});
-
-    // std::cerr << " prevout b " << test_tx.inputs_ptr()->front()->prevout->script().to_string(forks::no_rules) << std::endl;
-
-    // std::cerr << encode_base16(test_tx.to_data(false)) << std::endl;
-    // const ec_secret secret = base16_hash("ce8f4b713ffdd2658900845251890f30371856be201cd1f5b3d970f793634333");
-    std::cerr << "Spending transaction inputs size:: " <<
-        spending_transaction.inputs_ptr()->size() << std::endl;
-    std::cerr << "Spending transaction input script:: " <<
-        spending_transaction.inputs_ptr()->front()->script().to_string(forks::no_rules) << std::endl;
-    std::cerr << "Spending transaction OUTPUT size:: " <<
-        spending_transaction.outputs_ptr()->size() << std::endl;
-    std::cerr << "Spending transaction OUTPUT script:: " <<
-        spending_transaction.outputs_ptr()->front()->script().to_string(forks::all_rules) << std::endl;
     auto signatures = spending_transaction.generate_signatures(0u, secret_key, coverage::hash_all, {forks::no_rules,0});
 
-    // // const auto expected = base16_chunk("3045022100e428d3cc67a724cb6cfe8634aa299e58f189d9c46c02641e936c40cc16c7e8ed0220083949910fe999c21734a1f33e42fca15fb463ea2e08f0a1bccd952aacaadbb801");
-    // BOOST_REQUIRE_EQUAL(signatures.size(), 0);
+    BOOST_REQUIRE_EQUAL(encode_base16(signatures.front()), "3044022052be662338ea349319271ff945f09b006a25e71aa6bdee421ef064d6a701af8102205a07aead4ab5b99f09ac69fd4352cbfeb52105b2dfc9f333a407925de7fdefb3");
+
+    // Now use the signature generated and verify a transaction with the signature
+    const chain::transaction transaction_with_signature
+    {
+        1,
+        chain::inputs
+        {
+            chain::input
+            {
+                // coinbase
+                chain::point{ previous_transaction.hash(false), 0u },
+                // The signature is the secret key with sighash flasg appended at the end [<secret_key><sighash_flags>]
+                chain::script{"[3044022052be662338ea349319271ff945f09b006a25e71aa6bdee421ef064d6a701af8102205a07aead4ab5b99f09ac69fd4352cbfeb52105b2dfc9f333a407925de7fdefb300] [02b59709bc5c29246bd94d48e90dde62442e97d1ccd9a2315b6303c82b07aa4412]"},
+                1
+            },
+        },
+        chain::outputs
+        {
+            chain::output
+            {
+                90, // leave 10 as fee, spend back to d01 key hash
+                chain::script{"dup hash160 [d01453c0b2e4abaa6589fd156da42e875c413539] equalverify checksig"}
+            },
+        },
+        144
+    };
+
+    transaction_with_signature.inputs_ptr()->front()->prevout.reset(new prevout{0u, prevout_script});
+    BOOST_REQUIRE_EQUAL(transaction_with_signature.connect({forks::no_rules, 0}), error::transaction_success);
 }
-
-
-// // bip143 test cases.
-// // ----------------------------------------------------------------------------
-
-// BOOST_AUTO_TEST_CASE(script__verify__bip143_native_p2wpkh_tx__success)
-// {
-//     const auto decoded_tx = base16_chunk("01000000000102fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac000247304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635711000000");
-//     const transaction_accessor tx(decoded_tx, true);
-//     BOOST_REQUIRE(tx.is_valid());
-//     BOOST_REQUIRE_EQUAL(tx.inputs_ptr()->size(), 2u);
-//     BOOST_REQUIRE((*tx.inputs_ptr())[0]->witness().stack().empty());
-//     BOOST_REQUIRE(!(*tx.inputs_ptr())[1]->witness().stack().empty());
-
-//     constexpr auto value0 = 625000000u;
-//     (*tx.inputs_ptr())[0]->prevout.reset(new prevout{ value0, { base16_chunk("2103c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432ac"), false } });
-
-//     constexpr auto value1 = 600000000u;
-//     (*tx.inputs_ptr())[1]->prevout.reset(new prevout{ value1, { base16_chunk("00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1"), false } });
-
-//     // ordinary P2PK (no rules required).
-//     BOOST_REQUIRE_EQUAL(tx.connect({ forks::no_rules }, 0), error::script_success);
-
-//     // P2WPKH witness program.
-//     BOOST_REQUIRE_EQUAL(tx.connect({ forks::bip141_rule | forks::bip143_rule }, 1), error::script_success);
-
-//     // Other scenarios:
-
-//     // extra rules (okay).
-//     BOOST_REQUIRE_EQUAL(tx.connect({ forks::bip141_rule | forks::bip143_rule }, 0), error::script_success);
-
-//     // missing bip143 (invalid sighash).
-//     BOOST_REQUIRE_EQUAL(tx.connect({ forks::bip141_rule }, 1), error::stack_false);
-
-//     // missing bip141 (witness not allowed).
-//     BOOST_REQUIRE_EQUAL(tx.connect({ forks::bip143_rule }, 1), error::unexpected_witness);
-
-//     // missing bip141 (witness not allowed).
-//     BOOST_REQUIRE_EQUAL(tx.connect({ forks::no_rules }, 1), error::unexpected_witness);
-// }
-
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is a draft PR for initial discussion on how to continue on the work to provide transaction signing using connect.

## What we currently do 

1. Added a new method in transaction called
   `transaction::generate_signatures` that calls a new method in
   `interpreter` calls `interpreter::connect_for_signing`.
2. The `interpreter::connect_for_signing` calls the
   `interpreter::connect` creates a `program` with `sign_mode_`
   boolean flag set to true.
3. If this flag is set during a programs `run`, then we sign the
   transaction and gather signatures.
4. To gather signatures, we track generated signatures in a vector of
   `der_signature`s in the `program`.
5. For signing, we provide the private keys in the signature
   fields. We append sighash flags to the private key. So the
   signature in sign mode has `<private_key><flags>`.
6. Once signing is completed by the `check_sig_verify` and
   `checksig_multisig_verify` methods the interpreter takes the
   signatures from the programs and adds them to the out param
   `signatures` passed in to the `connect_for_signing` and
   `transaction::connect` methods.

![image](https://user-images.githubusercontent.com/13216/208874320-4b553a8b-7b57-4e15-9106-1f1844682a8a.png)

## What we should consider doing

1. We should use template member function to evaluate the `if
   (sign_mode_)` condition at compile time. This will require turning
   `connect` and `run` into template member function that take a bool
   template argument to identify if things are running in signing mode or not.
2. We should refactor `interpreter::connect` to break it into smaller methods
   1. It might be worthwhile to consider a new class like
      `transaction_connector` that hides away all the connection logic
      in one place away from the `transaction` class.
   2. This will help a lot in working on templatizing the `connect`
      member functions.
3. We also need to write tests to cover the segwit cases.

