### PR TITLE
Initial work for signing transactions with prepare

### DIFF
--- a/builds/cmake/CMakeLists.txt
+++ b/builds/cmake/CMakeLists.txt
@@ -515,6 +515,7 @@ if (with-tests)
         "../../test/chain/script.hpp"
         "../../test/chain/stripper.cpp"
         "../../test/chain/transaction.cpp"
+        "../../test/chain/transaction_signing.cpp"
         "../../test/chain/witness.cpp"
         "../../test/chain/enums/opcode.cpp"
         "../../test/config/base16.cpp"

--- a/include/bitcoin/system/chain/transaction.hpp
+++ b/include/bitcoin/system/chain/transaction.hpp
@@ -143,6 +143,11 @@ public:
     code accept(const context& state) const NOEXCEPT;
     code connect(const context& state) const NOEXCEPT;
 
+    // Signing (for use in wallets)
+    // ------------------------------------------------------------------------
+    endorsements generate_signatures(const uint8_t input_index,
+        const context& state) const;
+
 protected:
     transaction(uint32_t version, const chain::inputs_cptr& inputs,
         const chain::outputs_cptr& outputs, uint32_t locktime, bool segregated,

--- a/include/bitcoin/system/impl/machine/interpreter.ipp
+++ b/include/bitcoin/system/impl/machine/interpreter.ipp
@@ -1650,24 +1650,22 @@ connect(const context& state, const transaction& tx,
         return error::missing_previous_output;
 
     // Evaluate input script.
-    interpreter in_program(tx, it, state.forks);
+    interpreter in_program(tx, it, state.forks, sign_mode);
     if ((ec = in_program.run()))
         return ec;
 
     if (sign_mode)
-        interpreter::collect_signatures(signatures, input_program.generated_signatures());
+        interpreter::collect_signatures(signatures, in_program.generated_signatures());
 
     // Evaluate output script using stack copied from input script evaluation.
     const auto& prevout = input.prevout->script_ptr();
     interpreter out_program(in_program, prevout);
     if ((ec = out_program.run()))
-    {
         return ec;
-    }
 
     if (sign_mode)
         interpreter::collect_signatures(signatures, out_program.generated_signatures());
-    
+
     if (!out_program.is_true(false))
     {
         return error::stack_false;
@@ -1778,7 +1776,7 @@ code interpreter<Stack>::connect_witness(const context &state,
 
             if (sign_mode){
                 interpreter::collect_signatures(signatures,
-                    witness_program.generated_signatures());
+                    program.generated_signatures());
             }
 
             // A v0 script must succeed with a clean true stack (bip141).

--- a/include/bitcoin/system/machine/interpreter.hpp
+++ b/include/bitcoin/system/machine/interpreter.hpp
@@ -19,6 +19,7 @@
 #ifndef LIBBITCOIN_SYSTEM_MACHINE_INTERPRETER_HPP
 #define LIBBITCOIN_SYSTEM_MACHINE_INTERPRETER_HPP
 
+#include "bitcoin/system/crypto/secp256k1.hpp"
 #include <bitcoin/system/data/data.hpp>
 #include <bitcoin/system/define.hpp>
 #include <bitcoin/system/error/error.hpp>
@@ -51,18 +52,29 @@ public:
     static code connect(const context& state, const transaction& tx,
         uint32_t index) NOEXCEPT;
 
-    /// Connect tx.input[*].script to tx.input[*].prevout.script.
+    /// Connect tx.input[#].script to tx.input[#].prevout.script.
+    static code connect(const context& state, const transaction& tx,
+        uint32_t index, endorsements& signatures) NOEXCEPT;
+
+    /// Connect tx.input[*].script to tx.input[*].prevout.script for signing.
     static code connect(const context& state, const transaction& tx,
         const input_iterator& it) NOEXCEPT;
+
+    /// Connect tx.input[*].script to tx.input[*].prevout.script for signing.
+    static code connect(const context& state, const transaction& tx,
+        const input_iterator& it, endorsements& signatures,
+        const bool sign_mode=false) NOEXCEPT;
 
 protected:
     /// Embedded script handler.
     static code connect_embedded(const context& state, const transaction& tx,
-        const input_iterator& it, interpreter& in_program) NOEXCEPT;
+        const input_iterator& it, interpreter& input_program,
+        endorsements& signatures, const bool sign_mode) NOEXCEPT;
 
     /// Witnessed script handler.
     static code connect_witness(const context& state, const transaction& tx,
-        const input_iterator& it, const script& prevout) NOEXCEPT;
+        const input_iterator& it, const script& prevout_script,
+        endorsements& signatures, const bool sign_mode) NOEXCEPT;
 
     /// Operation disatch.
     error::op_error_t run_op(const op_iterator& op) NOEXCEPT;
@@ -154,6 +166,12 @@ protected:
     inline error::op_error_t op_check_multisig() NOEXCEPT;
     inline error::op_error_t op_check_locktime_verify() const NOEXCEPT;
     inline error::op_error_t op_check_sequence_verify() const NOEXCEPT;
+
+private:
+  static void collect_signatures(endorsements& target,
+      const endorsements& signatures_to_collect);
+  static void collect_signing_keys(data_stack& target,
+      const data_stack& keys_to_collect);
 };
 
 } // namespace machine

--- a/src/chain/transaction.cpp
+++ b/src/chain/transaction.cpp
@@ -1296,6 +1296,18 @@ code transaction::connect(const context& state) const NOEXCEPT
     return error::transaction_success;
 }
 
+// Sign
+// ------------------------------------------------------------------------
+
+endorsements transaction::generate_signatures(const uint8_t input_index,
+    const context& state) const
+{
+  endorsements signatures;
+  machine::interpreter<machine::contiguous_stack>::connect(state, *this,
+      input_index, signatures);
+  return signatures;
+}
+
 // JSON value convertors.
 // ----------------------------------------------------------------------------
 

--- a/test/chain/script.cpp
+++ b/test/chain/script.cpp
@@ -297,6 +297,18 @@ BOOST_AUTO_TEST_CASE(script__from_string__empty__success)
     BOOST_REQUIRE(instance.ops().empty());
 }
 
+BOOST_AUTO_TEST_CASE(script__from_string__p2pkh__success)
+{
+    const script instance("dup hash160 [abe507d92d415f688f3c22ca9689404df66edb5e] checksigverify");
+    BOOST_REQUIRE(instance.is_valid());
+
+    const auto& ops = instance.ops();
+    BOOST_REQUIRE(ops[0] == opcode::dup);
+    BOOST_REQUIRE(ops[1] == opcode::hash160);
+    BOOST_REQUIRE_EQUAL(ops[2].to_string(forks::no_rules), "[abe507d92d415f688f3c22ca9689404df66edb5e]");
+    BOOST_REQUIRE(ops[3] == opcode::checksigverify);
+}
+
 BOOST_AUTO_TEST_CASE(script__from_string__two_of_three_multisig__success)
 {
     const script instance(script_2_of_3_multisig);

--- a/test/chain/transaction_signing.cpp
+++ b/test/chain/transaction_signing.cpp
@@ -286,6 +286,7 @@ BOOST_AUTO_TEST_CASE(transaction__generate_signatures__multi_sig__expected)
     spending_transaction.inputs_ptr()->front()->prevout.reset(new output{0u, prevout_script});
     auto signatures = spending_transaction.generate_signatures(0u, {forks::no_rules,0});
 
+    BOOST_REQUIRE_EQUAL(signatures.size(), 3);
     BOOST_REQUIRE_EQUAL(encode_base16(signatures.at(0)), "3044022061ccdc51a4f1b7bd6e1d89b945336bd18aad0bce3f2e9657826487569b64d96502201a3d0e8e2bc70ce0fcd8358d177ec6d710b0a0ddd6c9586729a00aab5fe49ede");
     BOOST_REQUIRE_EQUAL(encode_base16(signatures.at(1)), "3044022010a3645d88dfa9d79e7ec90891fd306a082a855880a9fff5c47235eb4abb7c260220610d09672aead8e79e64da2c841b0a0f3579866aa73a2fc24e2d6935b798d1ea");
     BOOST_REQUIRE_EQUAL(encode_base16(signatures.at(2)), "3045022100c0675c34df1f678892d4babc44e5cd38bc6dd80e497a5860a276cd44961845a00220035369825776a15f81c2c163aa09dad00d1e0ba06a59e1868badac424f06ea4e");

--- a/test/chain/transaction_signing.cpp
+++ b/test/chain/transaction_signing.cpp
@@ -1,0 +1,323 @@
+/**
+ * Copyright (c) 2011-2022 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "../test.hpp"
+#include <boost/test/tools/old/interface.hpp>
+#include <sstream>
+#include "bitcoin/system/chain/enums/coverage.hpp"
+#include "bitcoin/system/chain/enums/forks.hpp"
+#include "bitcoin/system/chain/enums/script_version.hpp"
+#include "bitcoin/system/chain/script.hpp"
+#include "bitcoin/system/chain/transaction.hpp"
+#include "bitcoin/system/crypto/secp256k1.hpp"
+#include "bitcoin/system/error/op_error_t.hpp"
+#include "bitcoin/system/error/transaction_error_t.hpp"
+#include "bitcoin/system/radix/base_16.hpp"
+#include "script.hpp"
+
+BOOST_AUTO_TEST_SUITE(transaction_sign_tests)
+
+using namespace system::chain;
+using namespace system::machine;
+
+// Test helpers.
+// -----------------------------------------------------------------------------
+
+class transaction_accessor
+  : public transaction
+{
+public:
+    using transaction::transaction;
+
+    code connect(const context& state) const NOEXCEPT
+    {
+        return transaction::connect(state);
+    }
+
+    code connect(const context& state, uint32_t index) const NOEXCEPT
+    {
+        return interpreter<contiguous_stack>::connect(state, *this, index);
+    }
+};
+
+transaction_accessor test_tx(const script_test& test)
+{
+    const script in{ test.input };
+    const script out{ test.output };
+
+    if (!in.is_valid() || !out.is_valid())
+        return {};
+
+    const transaction_accessor tx
+    {
+        test.version,
+        inputs
+        {
+            {
+                point{},
+                in,
+                test.input_sequence
+            }
+        },
+        outputs{},
+        test.locktime
+    };
+
+    tx.inputs_ptr()->front()->prevout.reset(new output{ 0u, out });
+    return tx;
+}
+
+std::string test_name(const script_test& test)
+{
+    std::stringstream out;
+    out << "input: \"" << test.input << "\" "
+        << "prevout: \"" << test.output << "\" "
+        << "("
+            << test.input_sequence << ", "
+            << test.locktime << ", "
+            << test.version
+        << ") "
+        << "name: " << test.description;
+    return out.str();
+}
+
+// The following tests are derived from the test/chain/transaction.cpp
+// create_endorsement tests
+
+// Seed: d31e623e6dff00d5c0fd3aff010b80cc63787a63cbd564cd
+// key: b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de
+// public_key: 02b59709bc5c29246bd94d48e90dde62442e97d1ccd9a2315b6303c82b07aa4412
+// public_key hash: ca041a6aed6e8ab099cd75d65f8ef99e669a2d95
+BOOST_AUTO_TEST_CASE(transaction__generate_signatures__single_input_single_output__expected)
+{
+    // const ec_secret secret_key = base16_array("b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de");
+    const chain::transaction previous_transaction
+    {
+        1,
+        chain::inputs
+        {
+            chain::input
+            {
+                
+                // coinbase
+                chain::point{ null_hash, point::null_index },
+                chain::script{},
+                1
+            },
+        },
+        chain::outputs
+        {
+            chain::output
+            {
+                100,
+                chain::script{"dup hash160 [ca041a6aed6e8ab099cd75d65f8ef99e669a2d95] equalverify checksig"}
+            },
+        },
+        144
+    };
+
+    const chain::transaction spending_transaction
+    {
+        1,
+        chain::inputs
+        {
+            chain::input
+            {
+                
+                // coinbase
+                chain::point{ previous_transaction.hash(false), 0u },
+                // The signature is the secret key with sighash appended at the end [<secret_key><sighash_flags>]
+                chain::script{"[b1a44402170506553b367a6496cc7650ca1849a46eb4e01f5e4f5b72ef5e17de00] [02b59709bc5c29246bd94d48e90dde62442e97d1ccd9a2315b6303c82b07aa4412]"},
+                1
+            },
+        },
+        chain::outputs
+        {
+            chain::output
+            {
+                90, // leave 10 as fee, spend back to d01 key hash
+                chain::script{"dup hash160 [d01453c0b2e4abaa6589fd156da42e875c413539] equalverify checksig"}
+            },
+        },
+        144
+    };
+    
+    
+    BOOST_REQUIRE(previous_transaction.is_valid());
+    BOOST_REQUIRE(spending_transaction.is_valid());
+
+    const auto prevout_script = previous_transaction.outputs_ptr()->front()->script();
+
+    spending_transaction.inputs_ptr()->front()->prevout.reset(new output{0u, prevout_script});
+    auto signatures = spending_transaction.generate_signatures(0u, {forks::no_rules,0});
+
+    BOOST_REQUIRE_EQUAL(signatures.size(), 1);
+    BOOST_REQUIRE_EQUAL(encode_base16(signatures.front()), "3044022052be662338ea349319271ff945f09b006a25e71aa6bdee421ef064d6a701af8102205a07aead4ab5b99f09ac69fd4352cbfeb52105b2dfc9f333a407925de7fdefb3");
+
+    // Now use the signature generated and verify a transaction with the signature
+    const chain::transaction transaction_with_signature
+    {
+        1,
+        chain::inputs
+        {
+            chain::input
+            {
+                // coinbase
+                chain::point{ previous_transaction.hash(false), 0u },
+                // The signature is the secret key with sighash flags appended at the end [<secret_key><sighash_flags>]
+                chain::script{"[3044022052be662338ea349319271ff945f09b006a25e71aa6bdee421ef064d6a701af8102205a07aead4ab5b99f09ac69fd4352cbfeb52105b2dfc9f333a407925de7fdefb300] [02b59709bc5c29246bd94d48e90dde62442e97d1ccd9a2315b6303c82b07aa4412]"},
+                1
+            },
+        },
+        chain::outputs
+        {
+            chain::output
+            {
+                90, // leave 10 as fee, spend back to d01 key hash
+                chain::script{"dup hash160 [d01453c0b2e4abaa6589fd156da42e875c413539] equalverify checksig"}
+            },
+        },
+        144
+    };
+
+    transaction_with_signature.inputs_ptr()->front()->prevout.reset(new output{0u, prevout_script});
+    BOOST_REQUIRE_EQUAL(transaction_with_signature.connect({forks::no_rules, 0}), error::transaction_success);
+}
+
+// Seed: dc8a55d61556ceb2d543303a2fd777e2071acdd8ecd7d519
+// key: c9da85e0d0e1a1d257276a0aa66e0d7dc2a39b81d54f1c61b05bf583331b94f3
+// public_key: 03074b1cf714f40b9efb1d4f94b9a89bb59ff41295b24e98da60975da53efe9e8f
+// public_key hash: b01bcce4fae20a5e15ee98bde467646d9eb5b982
+
+// Seed: c0ed221ac47c45b8160997af36ea50ac4f91a594dc3ef470
+// key: 7fbda819a08ad75598ed8e0fc2922067b021cb303ada3fb39a30ceeb43637ef5
+// public_key: 036409aef83435a39e1b450a3ceb5a985bd34b4326503da0773f083c60ed5380f0
+// public_key hash: d605bdfe586866d57d9e0c881bea1a1dfba21f9c
+
+// Seed: 857eeac2e542fda11292d35bbe7bb210cfba689b0da074fc
+// key: 460fecc346a20b389a256d10755a405a376932cccfd1ee68336168de54977feb
+// public_key: 0246831318859a2b1b1e82d73c913aba6827825777391211dced5dad6213e6bc67
+// public_key hash: 214d1b4f6c6d6670b570fa0e7b56c21b272fc440
+
+
+BOOST_AUTO_TEST_CASE(transaction__generate_signatures__multi_sig__expected)
+{
+    const secret_list secret_keys = {
+        base16_array("c9da85e0d0e1a1d257276a0aa66e0d7dc2a39b81d54f1c61b05bf583331b94f3"),
+        base16_array("7fbda819a08ad75598ed8e0fc2922067b021cb303ada3fb39a30ceeb43637ef5"),
+        base16_array("460fecc346a20b389a256d10755a405a376932cccfd1ee68336168de54977feb"),
+    };
+    const compressed_list public_keys = {
+        base16_array("03074b1cf714f40b9efb1d4f94b9a89bb59ff41295b24e98da60975da53efe9e8f"),
+        base16_array("036409aef83435a39e1b450a3ceb5a985bd34b4326503da0773f083c60ed5380f0"),
+        base16_array("0246831318859a2b1b1e82d73c913aba6827825777391211dced5dad6213e6bc67"),
+    };
+    const chain::transaction previous_transaction
+    {
+        1,
+        chain::inputs
+        {
+            chain::input
+            {
+                
+                // coinbase
+                chain::point{ null_hash, point::null_index },
+                chain::script{},
+                1
+            },
+        },
+        chain::outputs
+        {
+            chain::output
+            {
+                100,
+                chain::script{"3 [03074b1cf714f40b9efb1d4f94b9a89bb59ff41295b24e98da60975da53efe9e8f] [036409aef83435a39e1b450a3ceb5a985bd34b4326503da0773f083c60ed5380f0] [0246831318859a2b1b1e82d73c913aba6827825777391211dced5dad6213e6bc67] 3 checkmultisig"}
+            },
+        },
+        144
+    };
+
+    const chain::transaction spending_transaction
+    {
+        1,
+        chain::inputs
+        {
+            chain::input
+            {
+                // coinbase
+                chain::point{ previous_transaction.hash(false), 0u },
+                // The signature is the secret key with sighash appended at the end [<secret_key><sighash_flags>]
+                chain::script{"0 [c9da85e0d0e1a1d257276a0aa66e0d7dc2a39b81d54f1c61b05bf583331b94f300] [7fbda819a08ad75598ed8e0fc2922067b021cb303ada3fb39a30ceeb43637ef500] [460fecc346a20b389a256d10755a405a376932cccfd1ee68336168de54977feb00]"},
+                1
+            },
+        },
+        chain::outputs
+        {
+            chain::output
+            {
+                90, // leave 10 as fee, spend back to d01 key hash
+                chain::script{"dup hash160 [d01453c0b2e4abaa6589fd156da42e875c413539] equalverify checksig"}
+            },
+        },
+        144
+    };
+    
+    
+    BOOST_REQUIRE(previous_transaction.is_valid());
+    BOOST_REQUIRE(spending_transaction.is_valid());
+
+    const auto prevout_script = previous_transaction.outputs_ptr()->front()->script();
+
+    spending_transaction.inputs_ptr()->front()->prevout.reset(new output{0u, prevout_script});
+    auto signatures = spending_transaction.generate_signatures(0u, {forks::no_rules,0});
+
+    BOOST_REQUIRE_EQUAL(encode_base16(signatures.at(0)), "3044022061ccdc51a4f1b7bd6e1d89b945336bd18aad0bce3f2e9657826487569b64d96502201a3d0e8e2bc70ce0fcd8358d177ec6d710b0a0ddd6c9586729a00aab5fe49ede");
+    BOOST_REQUIRE_EQUAL(encode_base16(signatures.at(1)), "3044022010a3645d88dfa9d79e7ec90891fd306a082a855880a9fff5c47235eb4abb7c260220610d09672aead8e79e64da2c841b0a0f3579866aa73a2fc24e2d6935b798d1ea");
+    BOOST_REQUIRE_EQUAL(encode_base16(signatures.at(2)), "3045022100c0675c34df1f678892d4babc44e5cd38bc6dd80e497a5860a276cd44961845a00220035369825776a15f81c2c163aa09dad00d1e0ba06a59e1868badac424f06ea4e");
+    
+    // Now use the signature generated and verify a transaction with the signature
+    const chain::transaction transaction_with_signature
+    {
+        1,
+        chain::inputs
+        {
+            chain::input
+            {
+                // coinbase
+                chain::point{ previous_transaction.hash(false), 0u },
+                // The signature is the secret key with sighash flasg appended at the end [<secret_key><sighash_flags>]
+                chain::script{"0 [3045022100c0675c34df1f678892d4babc44e5cd38bc6dd80e497a5860a276cd44961845a00220035369825776a15f81c2c163aa09dad00d1e0ba06a59e1868badac424f06ea4e00] [3044022010a3645d88dfa9d79e7ec90891fd306a082a855880a9fff5c47235eb4abb7c260220610d09672aead8e79e64da2c841b0a0f3579866aa73a2fc24e2d6935b798d1ea00] [3044022061ccdc51a4f1b7bd6e1d89b945336bd18aad0bce3f2e9657826487569b64d96502201a3d0e8e2bc70ce0fcd8358d177ec6d710b0a0ddd6c9586729a00aab5fe49ede00]"},
+                1
+            },
+        },
+        chain::outputs
+        {
+            chain::output
+            {
+                90, // leave 10 as fee, spend back to d01 key hash
+                chain::script{"dup hash160 [d01453c0b2e4abaa6589fd156da42e875c413539] equalverify checksig"}
+            },
+        },
+        144
+    };
+
+    transaction_with_signature.inputs_ptr()->front()->prevout.reset(new output{0u, prevout_script});
+    BOOST_REQUIRE_EQUAL(transaction_with_signature.connect({forks::no_rules, 0}), error::transaction_success);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR ports over the signing mode on top of refactoring work to separate `connect_witness` and `connect_embeded`.

This should still not be merged as this brings in allocation and condition jumps in the transaction verification.

We can avoid at least the allocation by either using polymorphism for `program` and template functions for `connect`. I'll have a go at this.

This PR is just to share the current state and get feedback. 