### PR TITLE
Use explicit instantiation for accumulator<sha256>

### DIFF
--- a/builds/cmake/CMakeLists.txt
+++ b/builds/cmake/CMakeLists.txt
@@ -319,6 +319,7 @@ add_library( ${CANONICAL_LIB_NAME}
     "../../src/error/script_error_t.cpp"
     "../../src/error/transaction_error_t.cpp"
     "../../src/hash/checksum.cpp"
+    "../../src/hash/accumulators.cpp"
     "../../src/hash/siphash.cpp"
     "../../src/hash/vectorization/sha256_1_native.cpp"
     "../../src/hash/vectorization/sha256_2_shani.cpp"

--- a/include/bitcoin/system/hash/accumulator.hpp
+++ b/include/bitcoin/system/hash/accumulator.hpp
@@ -161,6 +161,9 @@ private:
     block_t buffer_{};
 };
 
+/// prevent implicit template instantiation
+extern template class accumulator<sha256>;
+
 } // namespace system
 } // namespace libbitcoin
 

--- a/src/hash/accumulators.cpp
+++ b/src/hash/accumulators.cpp
@@ -1,0 +1,11 @@
+#include <bitcoin/system/hash/accumulator.hpp>
+
+namespace libbitcoin {
+namespace system {
+
+/// explicit template instantiation
+template class accumulator<sha256>;
+
+}
+}
+


### PR DESCRIPTION
On Linux with gcc, we get libbitcoin-system.so => 61MB and libbitcoin-system-test => 117MB.

Removing implicit instantiation for a single template instance reduces the above to 49MB and 111MB.

### CI Failures

- I need to update libbitcoin-build to add the new file ../../src/hash/accumulators.cpp to CMakeLists.txt, autotools and vs config? 
- I only the new file to CMakeLists.txt for my local setup, so only cmake builds will pass.