### PR TITLE
Explicitly initialize accumulator sha512

### DIFF
--- a/include/bitcoin/system/hash/accumulator.hpp
+++ b/include/bitcoin/system/hash/accumulator.hpp
@@ -163,6 +163,7 @@ private:
 
 /// Prevent implicit template instantiation.
 extern template class accumulator<sha256>;
+extern template class accumulator<sha512>;
 
 } // namespace system
 } // namespace libbitcoin

--- a/src/hash/accumulator.cpp
+++ b/src/hash/accumulator.cpp
@@ -26,6 +26,7 @@ namespace system {
 
 /// Explicit template instantiation.
 template class accumulator<sha256>;
+template class accumulator<sha512>;
 
 }
 }


### PR DESCRIPTION
This saves another MB on library and test executable.