### PR TITLE
Avoid tautological compare warn by compilers w/o vector constexpr.

### DIFF
--- a/include/bitcoin/system/define.hpp
+++ b/include/bitcoin/system/define.hpp
@@ -61,9 +61,8 @@ namespace bc = libbitcoin;
 #else
     #include <cassert>
     namespace libbitcoin { constexpr auto build_checked = true; };
-    #define BC_RUNTIME(evaluate) if (!std::is_constant_evaluated()) { evaluate; }
-    #define BC_ASSERT(expression) BC_RUNTIME(assert(expression))
-    #define BC_ASSERT_MSG(expression, text) BC_RUNTIME(assert((expression)&&(text)))
+    #define BC_ASSERT(expression) assert(expression)
+    #define BC_ASSERT_MSG(expression, text) assert((expression)&&(text))
     #define BC_DEBUG_ONLY(expression) expression
 #endif
 

--- a/include/bitcoin/system/have.hpp
+++ b/include/bitcoin/system/have.hpp
@@ -183,7 +183,8 @@
     #define HAVE_CPP20
 #endif
 
-// Platforms support for C++20 features that we use varies.
+// Support for C++20 features we use varies.
+// en.cppreference.com/w/cpp/compiler_support
 // These are based on the compiler versions we test with, shown below.
 #if defined(HAVE_CPP20)
     // All versions.

--- a/include/bitcoin/system/have.hpp
+++ b/include/bitcoin/system/have.hpp
@@ -183,13 +183,37 @@
     #define HAVE_CPP20
 #endif
 
-/////// Other platforms not as far along (C++20).
-////#if defined(HAVE_CPP20) && defined(HAVE_MSC)
-    #define HAVE_RANGES
-    #define HAVE_CONSTEVAL
-    #define HAVE_STRING_CONSTEXPR
-    #define HAVE_VECTOR_CONSTEXPR
-////#endif
+// Platforms support for C++20 features that we use varies.
+// These are based on the compiler versions we test with, shown below.
+#if defined(HAVE_CPP20)
+    // All versions.
+    #if defined(HAVE_MSC)
+        #define HAVE_RANGES
+        #define HAVE_CONSTEVAL
+        #define HAVE_STRING_CONSTEXPR
+        #define HAVE_VECTOR_CONSTEXPR
+    #elif defined(HAVE_CLANG)
+        // Apple clang version 15.0.0 (clang-1500.0.40.1)
+        #if defined(HAVE_APPLE)
+            #define HAVE_RANGES
+            #define HAVE_CONSTEVAL
+            #define HAVE_STRING_CONSTEXPR
+            #define HAVE_VECTOR_CONSTEXPR
+        // Ubuntu clang version 15.0.7
+        #else
+            ////#define HAVE_RANGES    (N/A)
+            ////#define HAVE_CONSTEVAL (v17)
+            #define HAVE_STRING_CONSTEXPR
+            #define HAVE_VECTOR_CONSTEXPR
+        #endif
+    // gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04) 
+    #elif defined(HAVE_GCC)
+        #define HAVE_RANGES
+        #define HAVE_CONSTEVAL
+        ////#define HAVE_STRING_CONSTEXPR (v12)
+        ////#define HAVE_VECTOR_CONSTEXPR (v12)
+    #endif
+#endif
 
 /// No std::execution on clang (C++17).
 #if defined(HAVE_CPP17) && !defined(HAVE_CLANG)

--- a/include/bitcoin/system/have.hpp
+++ b/include/bitcoin/system/have.hpp
@@ -183,13 +183,13 @@
     #define HAVE_CPP20
 #endif
 
-/// Other platforms not as far along (C++20).
-#if defined(HAVE_CPP20) && defined(HAVE_MSC)
+/////// Other platforms not as far along (C++20).
+////#if defined(HAVE_CPP20) && defined(HAVE_MSC)
     #define HAVE_RANGES
     #define HAVE_CONSTEVAL
     #define HAVE_STRING_CONSTEXPR
     #define HAVE_VECTOR_CONSTEXPR
-#endif
+////#endif
 
 /// No std::execution on clang (C++17).
 #if defined(HAVE_CPP17) && !defined(HAVE_CLANG)

--- a/include/bitcoin/system/impl/hash/sha/algorithm.ipp
+++ b/include/bitcoin/system/impl/hash/sha/algorithm.ipp
@@ -1278,11 +1278,15 @@ merkle_hash(digests_t& digests) NOEXCEPT
 {
     static_assert(is_same_type<state_t, chunk_t>);
 
+// Avoid tautological warning (std::is_constant_evaluated() always false).
+#if defined(HAVE_VECTOR_CONSTEXPR)
     if (std::is_constant_evaluated())
     {
         merkle_hash_(digests);
     }
-    else if constexpr (vectorization)
+    else
+#endif
+    if constexpr (vectorization)
     {
         merkle_hash_dispatch(digests);
     }

--- a/include/bitcoin/system/warnings.hpp
+++ b/include/bitcoin/system/warnings.hpp
@@ -45,6 +45,7 @@
         #define TRUNCATED_CONSTANT 4310
         #define LOCAL_VARIABLE_NOT_INITIALIZED 4700
         #define NOT_INLINED 4714
+        #define DISCARDING_NON_DISCARDABLE 4834
 
         // Global (see below).
         #define LOCAL_HIDES_GLOBAL 4459
@@ -52,6 +53,7 @@
 
         // Lint.
         #define NO_DEREFERENCE_NULL_POINTER 6011
+        #define NO_IGNORE_RETURN_VALUE 6031
         #define NO_READ_OVERRUN 6385
         #define NO_WRITE_OVERRUN 6386
         #define NO_MALLOC_OR_FREE 26408

--- a/test/hash/performance/performance.hpp
+++ b/test/hash/performance/performance.hpp
@@ -126,7 +126,7 @@ void output(std::ostream& out, uint64_t time, float ghz, bool csv) noexcept
 // Each is hashed on the seed to preclude compiler/CPU optimization.
 
 template <size_t Size, bool Chunk = false>
-VCONSTEXPR auto get_data(size_t seed) noexcept
+auto get_data(size_t seed) noexcept
 {
     constexpr auto filler = [](auto seed, auto& data)
     {


### PR DESCRIPTION
Also updating platform s++20 support defines.