### PR TITLE
Specify std::error_code usage in parser.cpp, without it fails to comp…

### DIFF
--- a/src/config/parser.cpp
+++ b/src/config/parser.cpp
@@ -93,7 +93,7 @@ bool parser::load_configuration_variables(variables_map& variables,
     const auto config_path = get_config_option(variables, option_name);
 
     // If the existence test errors out we pretend there's no file :/.
-    error_code code;
+    std::error_code code;
     if (!config_path.empty() && exists(config_path, code))
     {
         const auto& path = config_path.string();


### PR DESCRIPTION
…ile on CPP17 amd above