### PR TITLE
install scripts: add -h as alias for --help

### DIFF
--- a/install-cmake.sh
+++ b/install-cmake.sh
@@ -239,7 +239,7 @@ display_help()
     display_message "  --prefix=<absolute-path> Library install location (defaults to /usr/local)."
     display_message "  --disable-shared         Disables shared library builds."
     display_message "  --disable-static         Disables static library builds."
-    display_message "  --help                   Display usage, overriding script execution."
+    display_message "  --help, -h               Display usage, overriding script execution."
     display_message ""
     display_message "All unrecognized options provided shall be passed as configuration options for "
     display_message "all dependencies."
@@ -252,7 +252,7 @@ parse_command_line_options()
     for OPTION in "$@"; do
         case $OPTION in
             # Standard script options.
-            (--help)                DISPLAY_HELP="yes";;
+            (--help|-h)             DISPLAY_HELP="yes";;
             (--verbose)             DISPLAY_VERBOSE="yes";;
 
             # Standard build options.

--- a/install-cmakepresets.sh
+++ b/install-cmakepresets.sh
@@ -246,7 +246,7 @@ display_help()
     display_message "  --prefix=<absolute-path> Library install location (defaults to /usr/local)."
     display_message "  --disable-shared         Disables shared library builds."
     display_message "  --disable-static         Disables static library builds."
-    display_message "  --help                   Display usage, overriding script execution."
+    display_message "  --help, -h               Display usage, overriding script execution."
     display_message ""
     display_message "All unrecognized options provided shall be passed as configuration options for "
     display_message "all dependencies."
@@ -259,7 +259,7 @@ parse_command_line_options()
     for OPTION in "$@"; do
         case $OPTION in
             # Standard script options.
-            (--help)                DISPLAY_HELP="yes";;
+            (--help|-h)             DISPLAY_HELP="yes";;
             (--verbose)             DISPLAY_VERBOSE="yes";;
 
             # Standard build options.

--- a/install.sh
+++ b/install.sh
@@ -239,7 +239,7 @@ display_help()
     display_message "  --prefix=<absolute-path> Library install location (defaults to /usr/local)."
     display_message "  --disable-shared         Disables shared library builds."
     display_message "  --disable-static         Disables static library builds."
-    display_message "  --help                   Display usage, overriding script execution."
+    display_message "  --help, -h               Display usage, overriding script execution."
     display_message ""
     display_message "All unrecognized options provided shall be passed as configuration options for "
     display_message "all dependencies."
@@ -252,7 +252,7 @@ parse_command_line_options()
     for OPTION in "$@"; do
         case $OPTION in
             # Standard script options.
-            (--help)                DISPLAY_HELP="yes";;
+            (--help|-h)             DISPLAY_HELP="yes";;
             (--verbose)             DISPLAY_VERBOSE="yes";;
 
             # Standard build options.


### PR DESCRIPTION
All executables in Libbitcoin have `--help` and `-h`, however `-h` is missing at the install scripts.

Which is unexpected and it happened to me a couple times that I used `-h` and that the install script executed instead of displaying help.
