### PR TITLE
fix(block::check) fix dead code on verification of empty block

### DIFF
--- a/src/chain/block.cpp
+++ b/src/chain/block.cpp
@@ -876,15 +876,15 @@ code block::identify(const context& ctx) const NOEXCEPT
 // Use of get_hash() in is_forward_reference makes this thread-unsafe.
 code block::check() const NOEXCEPT
 {
-    // empty_block is subset of first_not_coinbase.
     // type64 malleated is a subset of first_not_coinbase.
     // type32 malleated is a subset of is_internal_double_spend.
     if (is_oversized())
         return error::block_size_limit;
+    if (is_empty())
+        return error::empty_block;
     if (is_first_non_coinbase())
-        return (is_empty() ? error::empty_block :
-            (is_malleated() ? error::invalid_transaction_commitment :
-                error::first_not_coinbase));
+        return (is_malleated() ? error::invalid_transaction_commitment :
+                error::first_not_coinbase);
     if (is_extra_coinbases())
         return error::extra_coinbases;
     if (is_forward_reference())

--- a/test/chain/block.cpp
+++ b/test/chain/block.cpp
@@ -407,6 +407,11 @@ BOOST_AUTO_TEST_CASE(block__hash__default__matches_header_hash)
 // ----------------------------------------------------------------------------
 
 // check
+BOOST_AUTO_TEST_CASE(block__check__empty__empty_block)
+{
+    const block instance{};
+    BOOST_REQUIRE_EQUAL(instance.check(), error::empty_block);
+}
 // accept
 // connect
 


### PR DESCRIPTION
The `is_empty()` verification inside the `check()` function can never be `true`, since it is nested inside the `if (is_first_non_coinbase())` condition, that fails for empty blocks, so `check()` never actually signaled on an empty block.