### PR TITLE
Fail script execution on op_check_multisig errors

### DIFF
--- a/include/bitcoin/system/impl/machine/interpreter.ipp
+++ b/include/bitcoin/system/impl/machine/interpreter.ipp
@@ -1099,6 +1099,18 @@ op_check_multisig() NOEXCEPT
     if (bip66 && ec == error::op_check_multisig_parse_signature)
         return ec;
 
+    // Structural(hard) errors MUST fail and end script.
+    if ( ec == error::op_check_multisig_verify1 ||
+         ec == error::op_check_multisig_verify2 ||
+         ec == error::op_check_multisig_verify3 ||
+         ec == error::op_check_multisig_verify4 ||
+         ec == error::op_check_multisig_verify5 ||
+         ec == error::op_check_multisig_verify6 ||
+         ec == error::op_check_multisig_verify7 ||
+         ec == error::op_check_multisig_verify8 ||
+         ec == error::op_check_multisig_verify9)
+        return ec;
+
     state::push_bool(ec == error::op_success);
     return error::op_success;
 }

--- a/test/chain/script.cpp
+++ b/test/chain/script.cpp
@@ -641,6 +641,18 @@ BOOST_AUTO_TEST_CASE(script__multisig__bip66_invalid_der)
     }
 }
 
+BOOST_AUTO_TEST_CASE(script__multisig__soft_errors__push_false)
+{
+    for (const auto& test: valid_soft_error_multisig_scripts)
+    {
+        const auto tx = test_tx(test);
+        const auto name = test_name(test);
+        BOOST_REQUIRE_MESSAGE(tx.is_valid(), name);
+
+        BOOST_CHECK_MESSAGE(tx.connect({ flags::no_rules }, 0) ==
+            error::stack_false, name);
+    }
+}
 
 BOOST_AUTO_TEST_CASE(script__context_free__valid)
 {

--- a/test/chain/script.cpp
+++ b/test/chain/script.cpp
@@ -628,6 +628,20 @@ BOOST_AUTO_TEST_CASE(script__multisig__invalid)
     }
 }
 
+BOOST_AUTO_TEST_CASE(script__multisig__bip66_invalid_der)
+{
+    for (const auto& test: invalid_bip66_multisig_scripts)
+    {
+        const auto tx = test_tx(test);
+        const auto name = test_name(test);
+        BOOST_REQUIRE_MESSAGE(tx.is_valid(), name);
+
+        BOOST_CHECK_MESSAGE(tx.connect({ flags::bip66_rule }, 0) ==
+            error::op_check_multisig_parse_signature, name);
+    }
+}
+
+
 BOOST_AUTO_TEST_CASE(script__context_free__valid)
 {
     for (const auto& test: valid_context_free_scripts)

--- a/test/chain/script.hpp
+++ b/test/chain/script.hpp
@@ -137,6 +137,17 @@ const script_test_list invalid_multisig_scripts
     { "1", "nop nop nop nop nop nop nop nop nop nop nop nop nop 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 checkmultisigverify 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 checkmultisigverify 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 checkmultisigverify 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 checkmultisigverify 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 checkmultisigverify 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 checkmultisigverify 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 checkmultisigverify 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 checkmultisigverify 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 checkmultisigverify", "" },
 }};
 
+// These are invalid only under bip66 DER signature encoding.
+const script_test_list invalid_bip66_multisig_scripts
+{{
+    { "", "0 [0101] 1 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] 1 checkmultisig", "1-of-1 invalid DER signature" },
+    { "", "0 [0101] 1 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] [02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] 2 checkmultisig", "1-of-2 invalid DER signature" },
+    { "", "0 [0101] [0202] 2 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] [02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] 2 checkmultisig", "2-of-2 invalid DER signature" },
+    { "", "0 [0101] 1 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] [02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] [03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] 3 checkmultisig", "1-of-3 invalid DER signature" },
+    { "", "0 [0101] [0202] 2 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] [02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] [03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] 3 checkmultisig", "2-of-3 invalid DER signature" },
+    { "", "0 [0101] [0202] [0303] 3 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] [02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] [03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] 3 checkmultisig", "3-of-3 invalid DER signature" }
+}};
+
 // These are always valid.
 const script_test_list valid_context_free_scripts
 {{

--- a/test/chain/script.hpp
+++ b/test/chain/script.hpp
@@ -148,6 +148,13 @@ const script_test_list invalid_bip66_multisig_scripts
     { "", "0 [0101] [0202] [0303] 3 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] [02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] [03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] 3 checkmultisig", "3-of-3 invalid DER signature" }
 }};
 
+// These return stack_false because checkmultisig soft errors push false.
+const script_test_list valid_soft_error_multisig_scripts
+{{
+    { "", "0 0 1 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] 1 checkmultisig", "unmatched empty signature pushes false" },
+    { "", "0 [0101] 1 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] 1 checkmultisig", "invalid DER parse pushes false without bip66" }
+}};
+
 // These are always valid.
 const script_test_list valid_context_free_scripts
 {{


### PR DESCRIPTION
- [aa0876c](https://github.com/KY-U/libbitcoin-system/commit/aa0876c3d9bf372bd673fb0a0227227b477019ac) Adds tests for script execution failure on invalid DER with bip66.
- [529876b](https://github.com/KY-U/libbitcoin-system/commit/529876bd65da5a976072374c2f8b0a6df1a399ed) Causes "hard" errors, such as errors related to consensus rules and stack structure to fail script execution instead of just pushing false to stack.
