### PR TITLE
fix(interpreter): fail op_check_sig when less than 2 items on stack

### DIFF
--- a/include/bitcoin/system/impl/machine/interpreter.ipp
+++ b/include/bitcoin/system/impl/machine/interpreter.ipp
@@ -991,6 +991,10 @@ op_check_sig() NOEXCEPT
 {
     const auto ec = op_check_sig_verify();
 
+    // If stack has less than 2 items, script MUST fail and end.
+    if ( ec == error::op_check_sig_verify1)
+        return ec;
+
     // BIP66: if DER encoding invalid script MUST fail and end.
     const auto bip66 = state::is_enabled(flags::bip66_rule);
     if (bip66 && ec == error::op_check_sig_parse_signature)

--- a/test/chain/script.hpp
+++ b/test/chain/script.hpp
@@ -846,7 +846,8 @@ const script_test_list invalid_context_free_scripts
     { "nop", "sha256 1", "" },
     { "nop", "hash160 1", "" },
     { "nop", "hash256 1", "" },
-    { "0x00", "'00' equal", "basic op_0 execution" }
+    { "0x00", "'00' equal", "basic op_0 execution" },
+    { "", "0xac 1", "op_checksig with empty stack must fail" }
 }};
 
 // These parse errors cannot happen in the libbitcoin syntax.


### PR DESCRIPTION
OP_CHECK_SIG called with less than 2 items on stack should fail script execution.