### PR TITLE
Only immediately fail op_check_sig_verify execution with empty key when BIP342 is activted.

### DIFF
--- a/include/bitcoin/system/impl/machine/interpreter.ipp
+++ b/include/bitcoin/system/impl/machine/interpreter.ipp
@@ -1022,12 +1022,12 @@ op_check_sig_verify() NOEXCEPT
     const auto key = state::pop_chunk_();
     const auto endorsement = state::pop_chunk_();
 
-    if (key->empty())
-        return error::op_check_sig_empty_key;
-
     // BIP342:
     if (state::is_enabled(flags::bip342_rule))
     {
+        if (key->empty())
+            return error::op_check_sig_empty_key;
+
         if (endorsement->empty())
             return error::op_check_sig_verify1;
 

--- a/test/chain/script.cpp
+++ b/test/chain/script.cpp
@@ -652,6 +652,22 @@ BOOST_AUTO_TEST_CASE(script__multisig__soft_errors__push_false)
     }
 }
 
+BOOST_AUTO_TEST_CASE(script__checksigverify__empty_key_without_bip342__empty_endorsement)
+{
+    const script_test test
+    {
+        "",
+        "0 0 checksigverify",
+        "empty legacy checksigverify key is not a tapscript empty-key error"
+    };
+    const auto tx = test_tx(test);
+    const auto name = test_name(test);
+    BOOST_REQUIRE_MESSAGE(tx.is_valid(), name);
+
+    BOOST_CHECK_MESSAGE(tx.connect({ flags::no_rules }, 0) == error::op_check_sig_verify2, name);
+    BOOST_CHECK_MESSAGE(tx.connect({ all_but_taproot }, 0) == error::op_check_sig_verify2, name);
+}
+
 BOOST_AUTO_TEST_CASE(script__context_free__valid)
 {
     for (const auto& test: valid_context_free_scripts)


### PR DESCRIPTION
Empty key is only a hard fail under BIP342. Legacy OPCHECKSIGVERIFY does eventually fail, so this change may be somewhat pedantic, but it matches more closely with Core's behaviour.