### PR TITLE
crypto: GPU/CPU batch signature verification (UltrafastSecp256k1 backend)

### DIFF
--- a/builds/cmake/CMakeLists.txt
+++ b/builds/cmake/CMakeLists.txt
@@ -28,6 +28,7 @@ option( enable-sse41 "Use SSE4.1 hardware instructions." OFF )
 option( enable-shani "Use Intel/ARM SHA Extensions." OFF )
 option( with-tests "Build tests." ON )
 option( with-examples "Build examples." ON )
+option( with-ultrafast "Use UltrafastSecp256k1 (GPU/CPU batch signature verification) as the secp256k1 backend." OFF )
 
 #------------------------------------------------------------------------------
 # Dependencies.
@@ -53,7 +54,46 @@ find_package( Boost 1.86.0 REQUIRED
     unit_test_framework
 )
 
-find_package( libsecp256k1 0.7.0 REQUIRED )
+if ( with-ultrafast )
+  #----------------------------------------------------------------------------
+  # UltrafastSecp256k1 secondary backend.
+  #
+  # Provides the libsecp256k1 ABI through its drop-in compatibility shim (so the
+  # existing libbitcoin crypto wrappers compile and link unchanged) PLUS the
+  # ufsecp_lbtc_* batch script-signature verify (ECDSA / Schnorr) and BIP-352
+  # scan entry points for GPU/CPU-accelerated block validation.
+  #
+  # Engine source is expected at deps/UltrafastSecp256k1 (git submodule) or at
+  # the path given by -DUltrafastSecp256k1_DIR=<path>.
+  # See doc/ultrafast-secp256k1-backend.md.
+  #----------------------------------------------------------------------------
+  if ( NOT UltrafastSecp256k1_DIR )
+    set( UltrafastSecp256k1_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../deps/UltrafastSecp256k1" )
+  endif()
+  if ( NOT EXISTS "${UltrafastSecp256k1_DIR}/CMakeLists.txt" )
+    message( FATAL_ERROR
+      "with-ultrafast=ON but UltrafastSecp256k1 was not found at '${UltrafastSecp256k1_DIR}'.\n"
+      "  git submodule update --init --recursive deps/UltrafastSecp256k1\n"
+      "or configure with -DUltrafastSecp256k1_DIR=/path/to/UltrafastSecp256k1" )
+  endif()
+  # Minimal libbitcoin profile: shim + CT + strict ABI + batch bridge, extras off.
+  set( SECP256K1_BUILD_LIBBITCOIN ON CACHE BOOL "UltrafastSecp256k1 libbitcoin profile" FORCE )
+  add_subdirectory( "${UltrafastSecp256k1_DIR}" ultrafast_secp256k1 EXCLUDE_FROM_ALL )
+  # Route libbitcoin's `libsecp256k1::secp256k1` dependency to the shim target.
+  if ( NOT TARGET libsecp256k1::secp256k1 )
+    add_library( libsecp256k1::secp256k1 ALIAS secp256k1_shim )
+  endif()
+  # Activate the batch bridge in libbitcoin's secp256k1 wrapper: WITH_ULTRAFAST
+  # makes ecdsa::batch_verify / schnorr::batch_verify dispatch to ufsecp_lbtc_*
+  # (without it they fall back to a parallel std::for_each over the singular
+  # calls). Expose the bridge header; its symbols come from the engine target
+  # built above under the libbitcoin profile.
+  add_compile_definitions( WITH_ULTRAFAST )
+  include_directories( "${UltrafastSecp256k1_DIR}/compat/libbitcoin_bridge/include" )
+  message( STATUS "libbitcoin-system: secp256k1 backend = UltrafastSecp256k1 (shim + ufsecp_lbtc batch bridge)" )
+else()
+  find_package( libsecp256k1 0.7.0 REQUIRED )
+endif()
 
 #------------------------------------------------------------------------------
 # Compiler options.

--- a/doc/ultrafast-secp256k1-backend.md
+++ b/doc/ultrafast-secp256k1-backend.md
@@ -1,0 +1,96 @@
+# UltrafastSecp256k1 secp256k1 backend (GPU/CPU batch signature verification)
+
+This is a **proposal / work-in-progress** integration that lets libbitcoin-system
+use [UltrafastSecp256k1](https://github.com/shrec/UltrafastSecp256k1) as its
+secp256k1 backend. It provides two things:
+
+1. **Drop-in libsecp256k1 ABI** — through the engine's compatibility shim, so the
+   existing `bitcoin/system/crypto/secp256k1.*` wrappers compile and link
+   **unchanged**. Single-signature behaviour is libsecp256k1-compatible.
+2. **Batch script-signature verification** — `ufsecp_lbtc_verify_ecdsa` /
+   `ufsecp_lbtc_verify_schnorr`: hand a node the `sig / key / sighash` triples
+   extracted from script execution as one array and get an array of per-row
+   pass/fail results back, GPU-accelerated with a mandatory CPU fallback. This
+   targets IBD / historical block validation (signatures are ~95% of script
+   cost), **not** mempool latency. A BIP-352 silent-payment scan entry point
+   (`ufsecp_lbtc_sp_scan`) is also exposed.
+
+> Status: build wiring + entry-point contract. The batch verification API is a
+> proposal agreed in principle; the IBD marshalling and the GPU-vs-CPU
+> consensus differential gate are to be built and tuned together.
+
+## Build
+
+```bash
+git submodule update --init --recursive deps/UltrafastSecp256k1
+
+cmake -S builds/cmake -B build \
+    -Dwith-ultrafast=ON \
+    -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+```
+
+- `-Dwith-ultrafast=ON` replaces `find_package(libsecp256k1)` with the engine
+  (built in its minimal `SECP256K1_BUILD_LIBBITCOIN` profile: shim + CT + strict
+  ABI, everything else off) and aliases `libsecp256k1::secp256k1` to the shim.
+- Engine location override: `-DUltrafastSecp256k1_DIR=/path/to/UltrafastSecp256k1`.
+- GPU acceleration: add a GPU backend to the engine configure, e.g.
+  `-DSECP256K1_BUILD_CUDA=ON` (or `-DSECP256K1_BUILD_OPENCL=ON`). Without one the
+  batch path runs on the CPU reference (still correct, just not accelerated).
+
+Default (`with-ultrafast=OFF`) keeps the stock `find_package(libsecp256k1 0.7.0)`
+behaviour — zero impact on existing builds.
+
+## Batch verification entry point
+
+Header: `ufsecp_libbitcoin.h` (from the engine; pure C / C++, no FFI). Link the
+engine C ABI library `ufsecp_static`.
+
+Records are packed into one unified table; ECDSA and Schnorr are **separate
+calls** (uniform data, stacked independently):
+
+| Kind    | Record (verified)                | Bytes |
+|---------|----------------------------------|-------|
+| ECDSA   | `32 msg ‖ 33 pubkey ‖ 64 sig`    | 129   |
+| Schnorr | `32 xonly ‖ 32 msg ‖ 64 sig`     | 128   |
+
+Each row may carry a trailing **opaque correlation key** (`key_size` bytes, e.g.
+a 3-byte block id or 4-byte tx id; `key_size = 0` disables it). The bridge never
+interprets it — it is carried so an invalid row maps back to its block/tx.
+
+```cpp
+#include <ufsecp_libbitcoin.h>
+
+ufsecp_lbtc_ctrl* ctrl = nullptr;
+ufsecp_lbtc_ctrl_create(&ctrl, UFSECP_LBTC_AUTO);   // GPU if available, else CPU
+
+// rows: n records of (129 + key_size) bytes, built from script sig/key/sighash.
+std::vector<uint8_t> results(n);
+std::vector<size_t>  invalid(n);
+size_t n_invalid = 0;
+
+ufsecp_lbtc_verify_ecdsa(ctrl, rows.data(), n, key_size,
+                         results.data(),            // per-row 1=valid / 0=invalid
+                         invalid.data(), n, &n_invalid);  // failing row indices
+
+if (n_invalid != 0) {
+    // block invalid — map invalid[i] back to its tx via the row's opaque key
+}
+ufsecp_lbtc_ctrl_destroy(ctrl);
+```
+
+`ufsecp_lbtc_verify_schnorr` is identical with the 128-byte Schnorr record.
+
+## Consensus
+
+The GPU path is consensus-bearing: its result must match the CPU /
+libsecp256k1-equivalent reference bit-for-bit (enforced by a differential gate on
+the engine side). The CPU fallback is always present and never optional.
+
+## What is here vs. what comes next
+
+- **Here:** build option + backend wiring + the batch entry-point contract and
+  usage. Single-signature verification works as a libsecp256k1 drop-in today.
+- **Next (to build/tune together):** marshalling the per-block signature jobs
+  into the batch arrays inside the IBD flow, the GPU-vs-CPU consensus
+  differential gate, and GPU throughput tuning on the real pipeline.

--- a/include/bitcoin/system/crypto/secp256k1.hpp
+++ b/include/bitcoin/system/crypto/secp256k1.hpp
@@ -221,6 +221,27 @@ BC_API bool recover_public(ec_uncompressed& out,
     const recoverable_signature& recoverable,
     const hash_digest& hash) NOEXCEPT;
 
+/// ECDSA batch verification (GPU/CPU acceleration bridge)
+/// ---------------------------------------------------------------------------
+/// Targets IBD/historical block validation, where signatures are ~95% of script
+/// cost. NOT a mempool-latency path.
+
+/// Packed batch record: 32 hash | 33 compressed point | 64 signature.
+static constexpr size_t batch_record_size = 129;
+
+/// Verify a packed batch of ECDSA signatures. Each row is one batch_record_size
+/// record optionally followed by key_size opaque bytes (a caller tag, e.g. a
+/// block/tx id; never interpreted here, pass key_size == 0 to disable). results
+/// is resized to count; results[i] is non-zero iff row i verifies. Returns false
+/// only on malformed input (e.g. rows too short); a structurally-invalid row is
+/// reported as results[i] == 0, not an error.
+///
+/// Compiled WITH_ULTRAFAST this dispatches to the UltrafastSecp256k1 batch bridge
+/// (GPU when a backend is linked, else its CPU path); otherwise it is a parallel
+/// std::for_each over the singular verify_signature.
+BC_API bool batch_verify(const data_slice& rows, size_t count, size_t key_size,
+    std_vector<uint8_t>& results) NOEXCEPT;
+
 } // namespace ecdsa
 
 namespace schnorr {
@@ -248,6 +269,20 @@ BC_API bool verify_signature(const ec_xonly& x_point,
 BC_API bool verify_commitment(const ec_xonly& internal_key,
     const hash_digest& tweak, const ec_xonly& tweaked_key,
     bool tweaked_key_parity) NOEXCEPT;
+
+/// Schnorr (BIP-340) batch verification (GPU/CPU acceleration bridge)
+/// ---------------------------------------------------------------------------
+
+/// Packed batch record: 32 x-only key | 32 hash | 64 signature.
+/// Note the deliberate field-order difference from ecdsa::batch_record_size:
+/// the hash is the FIRST field for ECDSA and the SECOND for Schnorr.
+static constexpr size_t batch_record_size = 128;
+
+/// Verify a packed batch of Schnorr/BIP-340 signatures. Row layout and result
+/// semantics mirror ecdsa::batch_verify (one batch_record_size record + optional
+/// key_size opaque tail per row; results[i] non-zero iff row i verifies).
+BC_API bool batch_verify(const data_slice& rows, size_t count, size_t key_size,
+    std_vector<uint8_t>& results) NOEXCEPT;
 
 } // namespace schnorr
 } // namespace system

--- a/src/crypto/secp256k1.cpp
+++ b/src/crypto/secp256k1.cpp
@@ -19,6 +19,7 @@
 #include <bitcoin/system/crypto/secp256k1.hpp>
 
 #include <algorithm>
+#include <numeric>
 #include <utility>
 #include <secp256k1.h>
 #include <secp256k1_recovery.h>
@@ -28,6 +29,20 @@
 #include <bitcoin/system/hash/hash.hpp>
 #include <bitcoin/system/math/math.hpp>
 #include "ec_context.hpp"
+
+// Batch signature verification dispatch.
+// WITH_ULTRAFAST: route the packed batch to the UltrafastSecp256k1 ⇄ libbitcoin
+// acceleration bridge (GPU when a backend is linked, else the engine CPU path).
+// Otherwise: a parallel std::for_each over the singular verify_signature — the
+// consensus reference and a benchmark baseline (the bridge must match it
+// bit-for-bit). The parallel policy is used where the toolchain provides it.
+#if defined(WITH_ULTRAFAST)
+#include <ufsecp_libbitcoin.h>
+#else
+// libbitcoin's vendored poolSTL maps std::execution::par to a portable thread
+// pool (no TBB dependency) and provides the parallel std::for_each overload.
+#include <bitcoin/system/execution.hpp>
+#endif
 
 namespace libbitcoin {
 namespace system {
@@ -475,6 +490,55 @@ bool recover_public(ec_uncompressed& out,
     return recover_public(context, out, recoverable, hash);
 }
 
+// ECDSA batch verification (GPU/CPU acceleration bridge)
+// ----------------------------------------------------------------------------
+
+bool batch_verify(const data_slice& rows, size_t count, size_t key_size,
+    std_vector<uint8_t>& results) NOEXCEPT
+{
+    results.assign(count, 0u);
+    if (is_zero(count))
+        return true;
+
+    const auto stride = batch_record_size + key_size;
+    if (rows.size() < count * stride)
+        return false;
+
+#if defined(WITH_ULTRAFAST)
+    // One bridge controller per worker thread: amortizes GPU device init and
+    // honors the bridge's "not internally synchronized" contract (libbitcoin
+    // verifies across validation threads).
+    static thread_local ufsecp::lbtc::Controller control{ UFSECP_LBTC_AUTO };
+    if (!control.ok())
+        return false;
+
+    size_t invalid_count{};
+    return ufsecp_lbtc_verify_ecdsa(control.get(), rows.data(), count, key_size,
+        results.data(), nullptr, 0, &invalid_count) == UFSECP_OK;
+#else
+    std_vector<size_t> index(count);
+    std::iota(index.begin(), index.end(), size_t{0});
+
+    const auto verify_row = [&](size_t row) NOEXCEPT
+    {
+        const auto record = std::next(rows.data(), row * stride);
+        hash_digest hash;
+        ec_compressed point;
+        ec_signature signature;
+        std::copy_n(record, hash_size, hash.begin());
+        std::copy_n(std::next(record, hash_size), ec_compressed_size,
+            point.begin());
+        std::copy_n(std::next(record, hash_size + ec_compressed_size),
+            ec_signature_size, signature.begin());
+        results[row] = verify_signature(point, hash, signature) ?
+            uint8_t{1} : uint8_t{0};
+    };
+
+    std::for_each(std::execution::par, index.begin(), index.end(), verify_row);
+    return true;
+#endif
+}
+
 } // namespace ecdsa
 
 namespace schnorr {
@@ -535,6 +599,52 @@ bool verify_commitment(const ec_xonly& internal_key, const hash_digest& tweak,
             ec_success &&
         secp256k1_xonly_pubkey_tweak_add_check(context, tweaked_key.data(),
             parity, &pubkey, tweak.data()) == ec_success;
+}
+
+// Schnorr (BIP-340) batch verification (GPU/CPU acceleration bridge)
+// ----------------------------------------------------------------------------
+
+bool batch_verify(const data_slice& rows, size_t count, size_t key_size,
+    std_vector<uint8_t>& results) NOEXCEPT
+{
+    results.assign(count, 0u);
+    if (is_zero(count))
+        return true;
+
+    const auto stride = batch_record_size + key_size;
+    if (rows.size() < count * stride)
+        return false;
+
+#if defined(WITH_ULTRAFAST)
+    static thread_local ufsecp::lbtc::Controller control{ UFSECP_LBTC_AUTO };
+    if (!control.ok())
+        return false;
+
+    size_t invalid_count{};
+    return ufsecp_lbtc_verify_schnorr(control.get(), rows.data(), count, key_size,
+        results.data(), nullptr, 0, &invalid_count) == UFSECP_OK;
+#else
+    std_vector<size_t> index(count);
+    std::iota(index.begin(), index.end(), size_t{0});
+
+    const auto verify_row = [&](size_t row) NOEXCEPT
+    {
+        // Schnorr record order: x-only key | hash | signature.
+        const auto record = std::next(rows.data(), row * stride);
+        ec_xonly key;
+        hash_digest hash;
+        ec_signature signature;
+        std::copy_n(record, ec_xonly_size, key.begin());
+        std::copy_n(std::next(record, ec_xonly_size), hash_size, hash.begin());
+        std::copy_n(std::next(record, ec_xonly_size + hash_size),
+            ec_signature_size, signature.begin());
+        results[row] = verify_signature(key, hash, signature) ?
+            uint8_t{1} : uint8_t{0};
+    };
+
+    std::for_each(std::execution::par, index.begin(), index.end(), verify_row);
+    return true;
+#endif
 }
 
 } // namespace schnorr

--- a/test/crypto/elliptic_curve.cpp
+++ b/test/crypto/elliptic_curve.cpp
@@ -147,6 +147,124 @@ BOOST_AUTO_TEST_CASE(elliptic_curve__verify_signature__negative__expected)
     BOOST_REQUIRE(!verify_signature(compressed2, sighash2, signature));
 }
 
+// batch verification
+// These exercise the CPU reference path (no WITH_ULTRAFAST in the test build);
+// the UltrafastSecp256k1 bridge path must match it bit-for-bit.
+
+BOOST_AUTO_TEST_CASE(elliptic_curve__ecdsa_batch_verify__all_valid__expected)
+{
+    const std_vector<ec_secret> secrets{ secret1, secret3, one };
+    const auto hash = bitcoin_hash(to_chunk("batch-ecdsa"));
+
+    // Pack rows: [32 hash | 33 point | 64 signature], no opaque key column.
+    data_chunk rows;
+    for (const auto& secret: secrets)
+    {
+        ec_compressed point;
+        BOOST_REQUIRE(secret_to_public(point, secret));
+        ec_signature signature;
+        BOOST_REQUIRE(sign(signature, secret, hash));
+        rows.insert(rows.end(), hash.begin(), hash.end());
+        rows.insert(rows.end(), point.begin(), point.end());
+        rows.insert(rows.end(), signature.begin(), signature.end());
+    }
+
+    std_vector<uint8_t> results;
+    BOOST_REQUIRE(batch_verify(rows, secrets.size(), 0, results));
+    BOOST_REQUIRE_EQUAL(results.size(), secrets.size());
+    for (const auto valid: results)
+        BOOST_REQUIRE_NE(valid, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(elliptic_curve__ecdsa_batch_verify__one_invalid_with_key__expected)
+{
+    const std_vector<ec_secret> secrets{ secret1, secret3, one, secret1 };
+    const auto hash = bitcoin_hash(to_chunk("batch-ecdsa-key"));
+    constexpr size_t key_size = 3; // 3-byte opaque block id, carried not verified
+
+    data_chunk rows;
+    for (size_t i = 0; i < secrets.size(); ++i)
+    {
+        ec_compressed point;
+        BOOST_REQUIRE(secret_to_public(point, secrets[i]));
+        ec_signature signature;
+        BOOST_REQUIRE(sign(signature, secrets[i], hash));
+        rows.insert(rows.end(), hash.begin(), hash.end());
+        rows.insert(rows.end(), point.begin(), point.end());
+        rows.insert(rows.end(), signature.begin(), signature.end());
+        rows.insert(rows.end(), { static_cast<uint8_t>(i), 0x00, 0x00 });
+    }
+
+    // Corrupt the signature of one row; its opaque key column is untouched.
+    constexpr size_t bad = 2;
+    const auto stride = ecdsa::batch_record_size + key_size;
+    rows[bad * stride + hash_size + ec_compressed_size + 10] ^= 0xff;
+
+    std_vector<uint8_t> results;
+    BOOST_REQUIRE(batch_verify(rows, secrets.size(), key_size, results));
+    for (size_t i = 0; i < results.size(); ++i)
+        BOOST_REQUIRE_EQUAL((results[i] != 0u), (i != bad));
+}
+
+BOOST_AUTO_TEST_CASE(elliptic_curve__schnorr_batch_verify__all_valid__expected)
+{
+    const std_vector<ec_secret> secrets{ secret1, secret3, one };
+    const auto hash = bitcoin_hash(to_chunk("batch-schnorr"));
+    const hash_digest auxiliary{};
+
+    // Pack rows: [32 x-only key | 32 hash | 64 signature].
+    data_chunk rows;
+    for (const auto& secret: secrets)
+    {
+        ec_compressed point;
+        BOOST_REQUIRE(secret_to_public(point, secret));
+        ec_xonly xonly;
+        std::copy_n(std::next(point.begin()), ec_xonly_size, xonly.begin());
+        ec_signature signature;
+        BOOST_REQUIRE(schnorr::sign(signature, secret, hash, auxiliary));
+        rows.insert(rows.end(), xonly.begin(), xonly.end());
+        rows.insert(rows.end(), hash.begin(), hash.end());
+        rows.insert(rows.end(), signature.begin(), signature.end());
+    }
+
+    std_vector<uint8_t> results;
+    BOOST_REQUIRE(schnorr::batch_verify(rows, secrets.size(), 0, results));
+    BOOST_REQUIRE_EQUAL(results.size(), secrets.size());
+    for (const auto valid: results)
+        BOOST_REQUIRE_NE(valid, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(elliptic_curve__schnorr_batch_verify__one_invalid__expected)
+{
+    const std_vector<ec_secret> secrets{ secret1, secret3, one };
+    const auto hash = bitcoin_hash(to_chunk("batch-schnorr-neg"));
+    const hash_digest auxiliary{};
+
+    data_chunk rows;
+    for (const auto& secret: secrets)
+    {
+        ec_compressed point;
+        BOOST_REQUIRE(secret_to_public(point, secret));
+        ec_xonly xonly;
+        std::copy_n(std::next(point.begin()), ec_xonly_size, xonly.begin());
+        ec_signature signature;
+        BOOST_REQUIRE(schnorr::sign(signature, secret, hash, auxiliary));
+        rows.insert(rows.end(), xonly.begin(), xonly.end());
+        rows.insert(rows.end(), hash.begin(), hash.end());
+        rows.insert(rows.end(), signature.begin(), signature.end());
+    }
+
+    // Corrupt one signature.
+    constexpr size_t bad = 1;
+    const auto stride = schnorr::batch_record_size;
+    rows[bad * stride + ec_xonly_size + hash_size + 10] ^= 0xff;
+
+    std_vector<uint8_t> results;
+    BOOST_REQUIRE(schnorr::batch_verify(rows, secrets.size(), 0, results));
+    for (size_t i = 0; i < results.size(); ++i)
+        BOOST_REQUIRE_EQUAL((results[i] != 0u), (i != bad));
+}
+
 // addition
 
 BOOST_AUTO_TEST_CASE(elliptic_curve__ec_add__positive__expected)


### PR DESCRIPTION
## Summary

Adds **batch signature verification** to `bitcoin/system/crypto/secp256k1` —
`ecdsa::batch_verify` and `schnorr::batch_verify` — targeting IBD / historical
block validation, where signature checks are ~95% of script-validation cost.
The node packs the `sig / key / sighash` triples extracted from script execution
(`CHECKSIG`, `CHECKMULTISIG`, Taproot `CHECKSIG` / `CHECKSIGADD`) into one byte
buffer and gets a per-row pass/fail array back — one call per kind. This is the
batch entry point discussed for the optional **UltrafastSecp256k1** secp256k1
backend (GPU/CPU accelerated, with a mandatory CPU fallback). Not a mempool path.

## Packed row layout

Homogeneous and uniform-size; ECDSA and Schnorr stack independently.

| Kind | Record | Bytes |
|------|--------|-------|
| ECDSA | `32 hash \| 33 point \| 64 signature` | 129 |
| Schnorr | `32 x-only key \| 32 hash \| 64 signature` | 128 |

Each row may carry an optional trailing **opaque key** of variable `key_size`
bytes (e.g. a 3-byte block id or 4-byte tx id). It is never interpreted — carried
only so an invalid row maps back to its block/tx without a second side table.
`key_size == 0` disables the column (stride == record size).

```cpp
bool ecdsa::batch_verify  (const data_slice& rows, size_t count, size_t key_size,
                           std_vector<uint8_t>& results) NOEXCEPT;
bool schnorr::batch_verify(const data_slice& rows, size_t count, size_t key_size,
                           std_vector<uint8_t>& results) NOEXCEPT;
```
`results` is sized to `count`; `results[i]` is non-zero iff row `i` verifies. A
structurally-invalid row reports `0` (not an error); `false` is returned only on
malformed input (rows too short).

## Two backends behind one signature

- **`WITH_ULTRAFAST`** — dispatch to the UltrafastSecp256k1 batch bridge
  (`ufsecp_lbtc_verify_ecdsa` / `_verify_schnorr`): GPU when a backend is linked,
  with a mandatory engine-side CPU fallback. One controller per worker thread.
- **otherwise** — a parallel `std::for_each` (the vendored poolSTL `par` policy)
  over the singular `verify_signature`. This is the **consensus reference** the
  GPU path must match bit-for-bit, and a benchmark baseline that also benefits
  the non-ultrafast build.

## Build

`with-ultrafast` (CMake) routes the secp256k1 backend to the engine's drop-in
libsecp256k1 ABI shim — single-signature ops compile and link **unchanged** — and
defines `WITH_ULTRAFAST` so the batch wrappers use the bridge. Engine at
`deps/UltrafastSecp256k1` (submodule) or `-DUltrafastSecp256k1_DIR=<path>`.

```bash
cmake -S builds/cmake -B build -Dwith-ultrafast=ON -DCMAKE_BUILD_TYPE=Release
```

Default build (`with-ultrafast=OFF`) is unchanged: stock libsecp256k1 +
the parallel CPU `batch_verify`.

## Tests

`test/crypto/elliptic_curve.cpp`: ECDSA and Schnorr `batch_verify` — all-valid,
one-invalid, and an opaque-key-column case. These exercise the CPU reference path.

## Notes

This is a **proposal / proof-of-concept** for review (per our discussion): the
design is the one we converged on — one unified table per call, separate
ECDSA/Schnorr, variable opaque key column, mandatory CPU fallback. The GPU-vs-CPU
**consensus differential** gate (GPU == CPU == libsecp256k1, bit-for-bit) lives
on the engine side; the IBD marshalling is the node side. A BIP-352 silent-payment
scan entry point (`ufsecp_lbtc_sp_scan`) is also exposed by the bridge for the
Electrum/server path. See `doc/ultrafast-secp256k1-backend.md`.