### PR TITLE
Enforce canonical compact size eight bytes tests

### DIFF
--- a/include/bitcoin/system/impl/stream/streamers/byte_reader.ipp
+++ b/include/bitcoin/system/impl/stream/streamers/byte_reader.ipp
@@ -202,17 +202,28 @@ uint64_t byte_reader<IStream>::read_8_bytes_little_endian() NOEXCEPT
 template <typename IStream>
 uint64_t byte_reader<IStream>::read_variable() NOEXCEPT
 {
-    switch (const auto value = read_byte())
+    uint64_t value;
+    switch (const auto length_byte = read_byte())
     {
         case varint_eight_bytes:
-            return read_8_bytes_little_endian();
+            value = read_8_bytes_little_endian();
+            if (value <= max_uint32)
+                invalid();
+            break;
         case varint_four_bytes:
-            return read_4_bytes_little_endian();
+            value = read_4_bytes_little_endian();
+            if (value <= max_uint16)
+                invalid();
+            break;
         case varint_two_bytes:
-            return read_2_bytes_little_endian();
+            value = read_2_bytes_little_endian();
+            if (value < varint_two_bytes)
+                invalid();
+            break;
         default:
-            return value;
+            value = length_byte;
     }
+    return value;
 }
 
 template <typename IStream>

--- a/test/stream/streamers/bit_flipper.cpp
+++ b/test/stream/streamers/bit_flipper.cpp
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "../../test.hpp"
+#include <cstring>
+#include <memory>
 #include <sstream>
 
 BOOST_AUTO_TEST_SUITE(stream_tests1)
@@ -967,24 +969,43 @@ BOOST_AUTO_TEST_CASE(bit_flipper__read_string__four_bytes__expected)
     BOOST_REQUIRE(reader);
 }
 
-// To test read_string with 8 bytes in canonical compact size representation
-// would require a string of 4,294,967,296 chars ~= 4GB.
-// BOOST_AUTO_TEST_CASE(bit_flipper__read_string__eight_bytes__expected)
-// {
-//     const std::string payload(4294967296ull, 'a');
-//     std::string value
-//     {
-//         static_cast<char>(varint_eight_bytes),
-//         0x00, 0x00, 0x00, 0x00,
-//         0x01, 0x00, 0x00, 0x00
-//     };
-//     value += payload;
-//
-//     std::stringstream stream{ value };
-//     flip::bits::iostream reader(stream);
-//     BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
-//     BOOST_REQUIRE(reader);
-// }
+BOOST_AUTO_TEST_CASE(bit_flipper__read_string__eight_bytes__expected)
+{
+    constexpr char header[]
+    {
+        static_cast<char>(varint_eight_bytes),
+        0x00, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x00, 0x00
+    };
+    constexpr auto payload_size = 4294967296ull;
+    const auto total_size = sizeof(header) + static_cast<size_t>(payload_size);
+
+    const auto buffer = std::make_unique<char[]>(total_size);
+    BOOST_REQUIRE(buffer);
+
+    auto* data = buffer.get();
+    std::memcpy(data, header, sizeof(header));
+    std::memset(data + sizeof(header), 'a', static_cast<size_t>(payload_size));
+
+    struct memory_streambuf
+      : public std::streambuf
+    {
+        memory_streambuf(char* begin, size_t size) NOEXCEPT
+        {
+            setg(begin, begin, begin + size);
+        }
+    };
+
+    memory_streambuf source(data, total_size);
+    std::iostream stream{ &source };
+    flip::bits::iostream reader(stream);
+
+    const auto payload = reader.read_string();
+    BOOST_REQUIRE_EQUAL(payload.size(), payload_size);
+    BOOST_REQUIRE_EQUAL(payload.front(), 'a');
+    BOOST_REQUIRE_EQUAL(payload.back(), 'a');
+    BOOST_REQUIRE(reader);
+}
 
 // read_string_buffer
 

--- a/test/stream/streamers/bit_flipper.cpp
+++ b/test/stream/streamers/bit_flipper.cpp
@@ -937,27 +937,54 @@ BOOST_AUTO_TEST_CASE(bit_flipper__read_string__one_byte__expected)
 
 BOOST_AUTO_TEST_CASE(bit_flipper__read_string__two_bytes__expected)
 {
-    const std::string value{ (char)varint_two_bytes, 0x03, 0x00, 'a', 'b', 'c' };
+    const std::string payload(253, 'a');
+    std::string value
+    {
+        static_cast<char>(varint_two_bytes),
+        static_cast<char>(0xfd), 0x00
+    };
+    value += payload;
+
     std::stringstream stream{ value };
     flip::bits::iostream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
 BOOST_AUTO_TEST_CASE(bit_flipper__read_string__four_bytes__expected)
 {
-    const std::string value{ (char)varint_four_bytes, 0x03, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
+    const std::string payload(65536, 'a');
+    std::string value
+    {
+        static_cast<char>(varint_four_bytes),
+        0x00, 0x00, 0x01, 0x00
+    };
+    value += payload;
+
     std::stringstream stream{ value };
     flip::bits::iostream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
-BOOST_AUTO_TEST_CASE(bit_flipper__read_string__eight_bytes__expected)
-{
-    const std::string value{ (char)varint_eight_bytes, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
-    std::stringstream stream{ value };
-    flip::bits::iostream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
-}
+// To test read_string with 8 bytes in canonical compact size representation
+// would require a string of 4,294,967,296 chars ~= 4GB.
+// BOOST_AUTO_TEST_CASE(bit_flipper__read_string__eight_bytes__expected)
+// {
+//     const std::string payload(4294967296ull, 'a');
+//     std::string value
+//     {
+//         static_cast<char>(varint_eight_bytes),
+//         0x00, 0x00, 0x00, 0x00,
+//         0x01, 0x00, 0x00, 0x00
+//     };
+//     value += payload;
+//
+//     std::stringstream stream{ value };
+//     flip::bits::iostream reader(stream);
+//     BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+//     BOOST_REQUIRE(reader);
+// }
 
 // read_string_buffer
 

--- a/test/stream/streamers/bit_reader.cpp
+++ b/test/stream/streamers/bit_reader.cpp
@@ -912,27 +912,58 @@ BOOST_AUTO_TEST_CASE(bit_reader__read_string__one_byte__expected)
 
 BOOST_AUTO_TEST_CASE(bit_reader__read_string__two_bytes__expected)
 {
-    const std::string value{ (char)varint_two_bytes, 0x03, 0x00, 'a', 'b', 'c' };
+    const std::string payload(253, 'a');
+    std::string value{
+        static_cast<char>(varint_two_bytes),
+        static_cast<char>(0xfd), 0x00
+    };
+
+    value += payload;
+
     std::istringstream stream{ value };
     read::bits::istream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
 BOOST_AUTO_TEST_CASE(bit_reader__read_string__four_bytes__expected)
 {
-    const std::string value{ (char)varint_four_bytes, 0x03, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
+    const std::string payload(65536, 'a');
+    std::string value{
+        static_cast<char>(varint_four_bytes),
+        static_cast<char>(0xfe), 0x00, 0x01, 0x00
+    };
+    value += payload;
+
     std::istringstream stream{ value };
     read::bits::istream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
-BOOST_AUTO_TEST_CASE(bit_reader__read_string__eight_bytes__expected)
-{
-    const std::string value{ (char)varint_eight_bytes, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
-    std::istringstream stream{ value };
-    read::bits::istream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
-}
+// To test read_string with 8 bytes in canonical compact size represesntation would require 
+// a string of 4,294,967,296 'chars' ~= 4GB, should we remove tha test?
+// BOOST_AUTO_TEST_CASE(bit_reader__read_string__eight_bytes__expected)
+// {
+//     const std::string payload(4294967296, 'a');
+//     std::string value;
+//     value.push_back(static_cast<char>(varint_eight_bytes));
+//     value.push_back(static_cast<char>(0xff));
+//     value.push_back(0x00);
+//     value.push_back(0x00);
+//     value.push_back(0x00);
+//     value.push_back(0x00);
+//     value.push_back(0x01);
+//     value.push_back(0x00);
+//     value.push_back(0x00);
+//     value.push_back(0x00);
+//     value += payload;
+
+//     std::istringstream stream{ value };
+//     read::bits::istream reader(stream);
+//     BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+//     BOOST_REQUIRE(reader);
+// }
 
 // read_string_buffer
 

--- a/test/stream/streamers/bit_reader.cpp
+++ b/test/stream/streamers/bit_reader.cpp
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "../../test.hpp"
+#include <cstring>
+#include <memory>
 #include <sstream>
 
 BOOST_AUTO_TEST_SUITE(stream_tests)
@@ -941,29 +943,43 @@ BOOST_AUTO_TEST_CASE(bit_reader__read_string__four_bytes__expected)
     BOOST_REQUIRE(reader);
 }
 
-// To test read_string with 8 bytes in canonical compact size represesntation would require 
-// a string of 4,294,967,296 'chars' ~= 4GB, should we remove tha test?
-// BOOST_AUTO_TEST_CASE(bit_reader__read_string__eight_bytes__expected)
-// {
-//     const std::string payload(4294967296, 'a');
-//     std::string value;
-//     value.push_back(static_cast<char>(varint_eight_bytes));
-//     value.push_back(static_cast<char>(0xff));
-//     value.push_back(0x00);
-//     value.push_back(0x00);
-//     value.push_back(0x00);
-//     value.push_back(0x00);
-//     value.push_back(0x01);
-//     value.push_back(0x00);
-//     value.push_back(0x00);
-//     value.push_back(0x00);
-//     value += payload;
+BOOST_AUTO_TEST_CASE(bit_reader__read_string__eight_bytes__expected)
+{
+    constexpr char header[]
+    {
+        static_cast<char>(varint_eight_bytes),
+        0x00, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x00, 0x00
+    };
+    constexpr auto payload_size = 4294967296ull;
+    const auto total_size = sizeof(header) + static_cast<size_t>(payload_size);
 
-//     std::istringstream stream{ value };
-//     read::bits::istream reader(stream);
-//     BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
-//     BOOST_REQUIRE(reader);
-// }
+    const auto buffer = std::make_unique<char[]>(total_size);
+    BOOST_REQUIRE(buffer);
+
+    auto* data = buffer.get();
+    std::memcpy(data, header, sizeof(header));
+    std::memset(data + sizeof(header), 'a', static_cast<size_t>(payload_size));
+
+    struct memory_streambuf
+      : public std::streambuf
+    {
+        memory_streambuf(char* begin, size_t size) NOEXCEPT
+        {
+            setg(begin, begin, begin + size);
+        }
+    };
+
+    memory_streambuf source(data, total_size);
+    std::istream stream{ &source };
+    read::bits::istream reader(stream);
+
+    const auto payload = reader.read_string();
+    BOOST_REQUIRE_EQUAL(payload.size(), payload_size);
+    BOOST_REQUIRE_EQUAL(payload.front(), 'a');
+    BOOST_REQUIRE_EQUAL(payload.back(), 'a');
+    BOOST_REQUIRE(reader);
+}
 
 // read_string_buffer
 

--- a/test/stream/streamers/byte_flipper.cpp
+++ b/test/stream/streamers/byte_flipper.cpp
@@ -937,27 +937,46 @@ BOOST_AUTO_TEST_CASE(byte_flipper__read_string__one_byte__expected)
 
 BOOST_AUTO_TEST_CASE(byte_flipper__read_string__two_bytes__expected)
 {
-    const std::string value{ (char)varint_two_bytes, 0x03, 0x00, 'a', 'b', 'c' };
+    const std::string payload(253, 'a');
+    std::string value{ (char)varint_two_bytes, static_cast<char>(0xfd), 0x00 };
+    value += payload;
+
     std::stringstream stream{ value };
     flip::bytes::iostream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
 BOOST_AUTO_TEST_CASE(byte_flipper__read_string__four_bytes__expected)
 {
-    const std::string value{ (char)varint_four_bytes, 0x03, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
+    const std::string payload(65536, 'a');
+    std::string value{ (char)varint_four_bytes, 0x00, 0x00, 0x01, 0x00 };
+    value += payload;
+
     std::stringstream stream{ value };
     flip::bytes::iostream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
-BOOST_AUTO_TEST_CASE(byte_flipper__read_string__eight_bytes__expected)
-{
-    const std::string value{ (char)varint_eight_bytes, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
-    std::stringstream stream{ value };
-    flip::bytes::iostream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
-}
+// To test read_string with 8 bytes in canonical compact size representation
+// would require a string of 4,294,967,296 chars ~= 4GB.
+// BOOST_AUTO_TEST_CASE(byte_flipper__read_string__eight_bytes__expected)
+// {
+//     const std::string payload(4294967296ull, 'a');
+//     std::string value
+//     {
+//         (char)varint_eight_bytes,
+//         0x00, 0x00, 0x00, 0x00,
+//         0x01, 0x00, 0x00, 0x00
+//     };
+//     value += payload;
+//
+//     std::stringstream stream{ value };
+//     flip::bytes::iostream reader(stream);
+//     BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+//     BOOST_REQUIRE(reader);
+// }
 
 // read_string_buffer
 

--- a/test/stream/streamers/byte_reader.cpp
+++ b/test/stream/streamers/byte_reader.cpp
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "../../test.hpp"
+#include <cstring>
+#include <memory>
 #include <sstream>
 
 BOOST_AUTO_TEST_SUITE(stream_tests)
@@ -1606,24 +1608,43 @@ BOOST_AUTO_TEST_CASE(byte_reader__read_string__four_bytes__expected)
     BOOST_REQUIRE(reader);
 }
 
-// To test read_string with 8 bytes in canonical compact size representation
-// would require a string of 4,294,967,296 chars ~= 4GB.
-// BOOST_AUTO_TEST_CASE(byte_reader__read_string__eight_bytes__expected)
-// {
-//     const std::string payload(4294967296ull, 'a');
-//     std::string value
-//     {
-//         static_cast<char>(varint_eight_bytes),
-//         0x00, 0x00, 0x00, 0x00,
-//         0x01, 0x00, 0x00, 0x00
-//     };
-//     value += payload;
-//
-//     std::istringstream stream{ value };
-//     read::bytes::istream reader(stream);
-//     BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
-//     BOOST_REQUIRE(reader);
-// }
+BOOST_AUTO_TEST_CASE(byte_reader__read_string__eight_bytes__expected)
+{
+    constexpr char header[]
+    {
+        static_cast<char>(varint_eight_bytes),
+        0x00, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x00, 0x00
+    };
+    constexpr auto payload_size = 4294967296ull;
+    const auto total_size = sizeof(header) + static_cast<size_t>(payload_size);
+
+    const auto buffer = std::make_unique<char[]>(total_size);
+    BOOST_REQUIRE(buffer);
+
+    auto* data = buffer.get();
+    std::memcpy(data, header, sizeof(header));
+    std::memset(data + sizeof(header), 'a', static_cast<size_t>(payload_size));
+
+    struct memory_streambuf
+      : public std::streambuf
+    {
+        memory_streambuf(char* begin, size_t size) NOEXCEPT
+        {
+            setg(begin, begin, begin + size);
+        }
+    };
+
+    memory_streambuf source(data, total_size);
+    std::istream stream{ &source };
+    read::bytes::istream reader(stream);
+
+    const auto payload = reader.read_string();
+    BOOST_REQUIRE_EQUAL(payload.size(), payload_size);
+    BOOST_REQUIRE_EQUAL(payload.front(), 'a');
+    BOOST_REQUIRE_EQUAL(payload.back(), 'a');
+    BOOST_REQUIRE(reader);
+}
 
 // read_string_buffer
 

--- a/test/stream/streamers/byte_reader.cpp
+++ b/test/stream/streamers/byte_reader.cpp
@@ -851,6 +851,40 @@ BOOST_AUTO_TEST_CASE(byte_reader__read_variable_size__eight_bytes__expected)
     }
 }
 
+// non-canonical variable size
+
+BOOST_AUTO_TEST_CASE(byte_reader__read_variable_size__non_canonical_two_bytes_expected)
+{
+    const std::string value{static_cast<char>(varint_two_bytes), 0x08, 0x00};
+    std::istringstream stream {value};
+    read::bytes::istream reader(stream);
+    BOOST_REQUIRE_EQUAL(reader.read_size(), 0x0008u);
+    reader.rewind_bytes(3);
+    reader.read_variable();
+    BOOST_REQUIRE(!reader);
+}
+
+BOOST_AUTO_TEST_CASE(byte_reader__read_variable_size__non_canonical_four_bytes_expected)
+{
+    const std::string value{static_cast<char>(varint_four_bytes), 0x08, 0x00, 0x00, 0x00};
+    std::istringstream stream {value};
+    read::bytes::istream reader(stream);
+    BOOST_REQUIRE_EQUAL(reader.read_size(), 0x00000008u);
+    reader.rewind_bytes(5);
+    reader.read_variable();
+    BOOST_REQUIRE(!reader);
+}
+
+BOOST_AUTO_TEST_CASE(byte_reader__read_variable_size__non_canonical_eight_bytes_expected)
+{
+    const std::string value{static_cast<char>(varint_eight_bytes), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    std::istringstream stream {value};
+    read::bytes::istream reader(stream);
+    BOOST_REQUIRE_EQUAL(reader.read_size(), 0x0000000000000000u);
+    reader.rewind_bytes(9);
+    reader.read_variable();
+    BOOST_REQUIRE(!reader);
+}
 
 // read_error_code
 
@@ -1550,27 +1584,46 @@ BOOST_AUTO_TEST_CASE(byte_reader__read_string__one_byte__expected)
 
 BOOST_AUTO_TEST_CASE(byte_reader__read_string__two_bytes__expected)
 {
-    const std::string value{ static_cast<char>(varint_two_bytes), 0x03, 0x00, 'a', 'b', 'c' };
+    const std::string payload(253, 'a');
+    std::string value{ static_cast<char>(varint_two_bytes), static_cast<char>(0xfd), 0x00 };
+    value += payload;
+
     std::istringstream stream{ value };
     read::bytes::istream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
 BOOST_AUTO_TEST_CASE(byte_reader__read_string__four_bytes__expected)
 {
-    const std::string value{ static_cast<char>(varint_four_bytes), 0x03, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
+    const std::string payload(65536, 'a');
+    std::string value{ static_cast<char>(varint_four_bytes), 0x00, 0x00, 0x01, 0x00 };
+    value += payload;
+
     std::istringstream stream{ value };
     read::bytes::istream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
-BOOST_AUTO_TEST_CASE(byte_reader__read_string__eight_bytes__expected)
-{
-    const std::string value{ static_cast<char>(varint_eight_bytes), 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
-    std::istringstream stream{ value };
-    read::bytes::istream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
-}
+// To test read_string with 8 bytes in canonical compact size representation
+// would require a string of 4,294,967,296 chars ~= 4GB.
+// BOOST_AUTO_TEST_CASE(byte_reader__read_string__eight_bytes__expected)
+// {
+//     const std::string payload(4294967296ull, 'a');
+//     std::string value
+//     {
+//         static_cast<char>(varint_eight_bytes),
+//         0x00, 0x00, 0x00, 0x00,
+//         0x01, 0x00, 0x00, 0x00
+//     };
+//     value += payload;
+//
+//     std::istringstream stream{ value };
+//     read::bytes::istream reader(stream);
+//     BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+//     BOOST_REQUIRE(reader);
+// }
 
 // read_string_buffer
 


### PR DESCRIPTION
- Validate canonical CompactSize encoding in `byte_reader::read_byte()`
- Fix existing tests that utilize non-canonical encodings.
- Add tests to check for rejecting non-canonical encodings.
I have removed string reading tests for `byte_reader`, `bit_reader`, and `bit_flipper` 8 bytes encoding since they were taking 1-2 min each. You can see the tested approach [here](https://github.com/KY-U/libbitcoin-system/commit/8047f6d29e9aef1b43192cf61752100aa7d4c094)