### PR TITLE
Reject non-canonical CompactSize encodings

### DIFF
--- a/include/bitcoin/system/impl/stream/streamers/byte_reader.ipp
+++ b/include/bitcoin/system/impl/stream/streamers/byte_reader.ipp
@@ -202,17 +202,28 @@ uint64_t byte_reader<IStream>::read_8_bytes_little_endian() NOEXCEPT
 template <typename IStream>
 uint64_t byte_reader<IStream>::read_variable() NOEXCEPT
 {
-    switch (const auto value = read_byte())
+    uint64_t value;
+    switch (const auto length_byte = read_byte())
     {
         case varint_eight_bytes:
-            return read_8_bytes_little_endian();
+            value = read_8_bytes_little_endian();
+            if (value <= max_uint32)
+                invalid();
+            break;
         case varint_four_bytes:
-            return read_4_bytes_little_endian();
+            value = read_4_bytes_little_endian();
+            if (value <= max_uint16)
+                invalid();
+            break;
         case varint_two_bytes:
-            return read_2_bytes_little_endian();
+            value = read_2_bytes_little_endian();
+            if (value < varint_two_bytes)
+                invalid();
+            break;
         default:
-            return value;
+            value = length_byte;
     }
+    return value;
 }
 
 template <typename IStream>

--- a/test/stream/streamers/bit_flipper.cpp
+++ b/test/stream/streamers/bit_flipper.cpp
@@ -937,26 +937,34 @@ BOOST_AUTO_TEST_CASE(bit_flipper__read_string__one_byte__expected)
 
 BOOST_AUTO_TEST_CASE(bit_flipper__read_string__two_bytes__expected)
 {
-    const std::string value{ (char)varint_two_bytes, 0x03, 0x00, 'a', 'b', 'c' };
+    const std::string payload(253, 'a');
+    std::string value
+    {
+        static_cast<char>(varint_two_bytes),
+        static_cast<char>(0xfd), 0x00
+    };
+    value += payload;
+
     std::stringstream stream{ value };
     flip::bits::iostream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
 BOOST_AUTO_TEST_CASE(bit_flipper__read_string__four_bytes__expected)
 {
-    const std::string value{ (char)varint_four_bytes, 0x03, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
-    std::stringstream stream{ value };
-    flip::bits::iostream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
-}
+    const std::string payload(65536, 'a');
+    std::string value
+    {
+        static_cast<char>(varint_four_bytes),
+        0x00, 0x00, 0x01, 0x00
+    };
+    value += payload;
 
-BOOST_AUTO_TEST_CASE(bit_flipper__read_string__eight_bytes__expected)
-{
-    const std::string value{ (char)varint_eight_bytes, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
     std::stringstream stream{ value };
     flip::bits::iostream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
 // read_string_buffer

--- a/test/stream/streamers/bit_reader.cpp
+++ b/test/stream/streamers/bit_reader.cpp
@@ -912,26 +912,33 @@ BOOST_AUTO_TEST_CASE(bit_reader__read_string__one_byte__expected)
 
 BOOST_AUTO_TEST_CASE(bit_reader__read_string__two_bytes__expected)
 {
-    const std::string value{ (char)varint_two_bytes, 0x03, 0x00, 'a', 'b', 'c' };
+    const std::string payload(253, 'a');
+    std::string value{
+        static_cast<char>(varint_two_bytes),
+        static_cast<char>(0xfd), 0x00
+    };
+
+    value += payload;
+
     std::istringstream stream{ value };
     read::bits::istream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
 BOOST_AUTO_TEST_CASE(bit_reader__read_string__four_bytes__expected)
 {
-    const std::string value{ (char)varint_four_bytes, 0x03, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
-    std::istringstream stream{ value };
-    read::bits::istream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
-}
+    const std::string payload(65536, 'a');
+    std::string value{
+        static_cast<char>(varint_four_bytes),
+        static_cast<char>(0xfe), 0x00, 0x01, 0x00
+    };
+    value += payload;
 
-BOOST_AUTO_TEST_CASE(bit_reader__read_string__eight_bytes__expected)
-{
-    const std::string value{ (char)varint_eight_bytes, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
     std::istringstream stream{ value };
     read::bits::istream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
 // read_string_buffer

--- a/test/stream/streamers/byte_flipper.cpp
+++ b/test/stream/streamers/byte_flipper.cpp
@@ -937,26 +937,26 @@ BOOST_AUTO_TEST_CASE(byte_flipper__read_string__one_byte__expected)
 
 BOOST_AUTO_TEST_CASE(byte_flipper__read_string__two_bytes__expected)
 {
-    const std::string value{ (char)varint_two_bytes, 0x03, 0x00, 'a', 'b', 'c' };
+    const std::string payload(253, 'a');
+    std::string value{ (char)varint_two_bytes, static_cast<char>(0xfd), 0x00 };
+    value += payload;
+
     std::stringstream stream{ value };
     flip::bytes::iostream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
 BOOST_AUTO_TEST_CASE(byte_flipper__read_string__four_bytes__expected)
 {
-    const std::string value{ (char)varint_four_bytes, 0x03, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
-    std::stringstream stream{ value };
-    flip::bytes::iostream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
-}
+    const std::string payload(65536, 'a');
+    std::string value{ (char)varint_four_bytes, 0x00, 0x00, 0x01, 0x00 };
+    value += payload;
 
-BOOST_AUTO_TEST_CASE(byte_flipper__read_string__eight_bytes__expected)
-{
-    const std::string value{ (char)varint_eight_bytes, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
     std::stringstream stream{ value };
     flip::bytes::iostream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
 // read_string_buffer

--- a/test/stream/streamers/byte_reader.cpp
+++ b/test/stream/streamers/byte_reader.cpp
@@ -851,6 +851,40 @@ BOOST_AUTO_TEST_CASE(byte_reader__read_variable_size__eight_bytes__expected)
     }
 }
 
+// non-canonical variable size
+
+BOOST_AUTO_TEST_CASE(byte_reader__read_variable_size__non_canonical_two_bytes_expected)
+{
+    const std::string value{static_cast<char>(varint_two_bytes), 0x08, 0x00};
+    std::istringstream stream {value};
+    read::bytes::istream reader(stream);
+    BOOST_REQUIRE_EQUAL(reader.read_size(), 0x0008u);
+    reader.rewind_bytes(3);
+    reader.read_variable();
+    BOOST_REQUIRE(!reader);
+}
+
+BOOST_AUTO_TEST_CASE(byte_reader__read_variable_size__non_canonical_four_bytes_expected)
+{
+    const std::string value{static_cast<char>(varint_four_bytes), 0x08, 0x00, 0x00, 0x00};
+    std::istringstream stream {value};
+    read::bytes::istream reader(stream);
+    BOOST_REQUIRE_EQUAL(reader.read_size(), 0x00000008u);
+    reader.rewind_bytes(5);
+    reader.read_variable();
+    BOOST_REQUIRE(!reader);
+}
+
+BOOST_AUTO_TEST_CASE(byte_reader__read_variable_size__non_canonical_eight_bytes_expected)
+{
+    const std::string value{static_cast<char>(varint_eight_bytes), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    std::istringstream stream {value};
+    read::bytes::istream reader(stream);
+    BOOST_REQUIRE_EQUAL(reader.read_size(), 0x0000000000000000u);
+    reader.rewind_bytes(9);
+    reader.read_variable();
+    BOOST_REQUIRE(!reader);
+}
 
 // read_error_code
 
@@ -1550,26 +1584,26 @@ BOOST_AUTO_TEST_CASE(byte_reader__read_string__one_byte__expected)
 
 BOOST_AUTO_TEST_CASE(byte_reader__read_string__two_bytes__expected)
 {
-    const std::string value{ static_cast<char>(varint_two_bytes), 0x03, 0x00, 'a', 'b', 'c' };
+    const std::string payload(253, 'a');
+    std::string value{ static_cast<char>(varint_two_bytes), static_cast<char>(0xfd), 0x00 };
+    value += payload;
+
     std::istringstream stream{ value };
     read::bytes::istream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
 BOOST_AUTO_TEST_CASE(byte_reader__read_string__four_bytes__expected)
 {
-    const std::string value{ static_cast<char>(varint_four_bytes), 0x03, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
-    std::istringstream stream{ value };
-    read::bytes::istream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
-}
+    const std::string payload(65536, 'a');
+    std::string value{ static_cast<char>(varint_four_bytes), 0x00, 0x00, 0x01, 0x00 };
+    value += payload;
 
-BOOST_AUTO_TEST_CASE(byte_reader__read_string__eight_bytes__expected)
-{
-    const std::string value{ static_cast<char>(varint_eight_bytes), 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'a', 'b', 'c' };
     std::istringstream stream{ value };
     read::bytes::istream reader(stream);
-    BOOST_REQUIRE_EQUAL(reader.read_string(), "abc");
+    BOOST_REQUIRE_EQUAL(reader.read_string(), payload);
+    BOOST_REQUIRE(reader);
 }
 
 // read_string_buffer


### PR DESCRIPTION
- Invalidate non canonical CompactSize encoding in `byte_reader::read_byte()`
- Fix existing tests that utilize non-canonical encodings.
- Add tests to check for invalidation of non-canonical encodings.

I have removed `byte_reader`, `bit_reader`, and `bit_flipper` 8 bytes encoding string reading tests since they were taking 1-2 min each. You can see the tested approach [here](https://github.com/KY-U/libbitcoin-system/commit/013bafe1a648affaa9a543ef5c619cf231345245).