### PR TITLE
Add padding byte validation during extended private key de-serialization to match bip 32's spec

### DIFF
--- a/src/wallet/keys/hd_private.cpp
+++ b/src/wallet/keys/hd_private.cpp
@@ -145,11 +145,15 @@ hd_private hd_private::from_key(const hd_key& key, uint64_t prefixes) NOEXCEPT
     const auto parent = source.read_4_bytes_big_endian();
     const auto child = source.read_4_bytes_big_endian();
     const auto chain = source.read_hash();
-    source.skip_byte();
+    const auto padding = source.read_byte();
     const auto secret = source.read_hash();
 
     // Validate the prefix against the provided value.
     if (prefix != to_prefix(prefixes))
+        return {};
+
+    // Validate the key padding.
+    if (padding != 0x00)
         return {};
 
     const hd_lineage lineage

--- a/test/wallet/keys/hd_private.cpp
+++ b/test/wallet/keys/hd_private.cpp
@@ -137,6 +137,14 @@ BOOST_AUTO_TEST_CASE(hd_private__constructor__null_key__decodes_to_invalid)
     BOOST_REQUIRE(!xprv_null);
 }
 
+BOOST_AUTO_TEST_CASE(hd_private__constructor__nonzero_private_key_padding__invalid)
+{
+    static const auto encoded = "tprvAk8SVSmAT8FFvWjCNUB546H9tsmRk5bii5WZvSY2zSnxSg4uuLFspzTZffwYUoYXqsP7WDdHTRS92WJzeXTki31ftCwzYCEnLAPt9a7aJyV";
+
+    const hd_private xprv_invalid(encoded);
+    BOOST_REQUIRE(!xprv_invalid);
+}
+
 BOOST_AUTO_TEST_CASE(hd_private__to_public__from_invalid_private__invalid)
 {
     // the 11...14rcJhr is a serialization of a null key;


### PR DESCRIPTION
Validate padding byte is 0 in extended private key de-serialization in order to match BIP 32's spec.