### PR TITLE
fix: verify taproot commitment for all leaf versions

### DIFF
--- a/src/chain/witness_extract.cpp
+++ b/src/chain/witness_extract.cpp
@@ -194,21 +194,24 @@ code witness::extract_taproot(hash_cptr& out_leaf, script::cptr& out_script,
             if (!control.is_valid())
                 return error::invalid_witness;
 
+            const auto& key = unsafe_array_cast<uint8_t, ec_xonly_size>(
+                program->data());
+
+            // The second-to-last stack element is the script.
+            const auto tapleaf = to_shared<script>(*pop(*out_stack), false);
+            const auto leaf = taproot::leaf_hash(control.version(), *tapleaf);
+
+            // Execute tapleaf script.
+            // out stack  : [stack-elements]
+            // out script : (popped-from-stack)
+            if (!taproot::verify_commit(control, key, leaf))
+                return error::invalid_commitment;
+
             if (control.is_tapscript())
             {
-                const auto& key = unsafe_array_cast<uint8_t, ec_xonly_size>(
-                    program->data());
-                
-                // The second-to-last stack element is the script.
-                out_script = to_shared<script>(*pop(*out_stack), false);
-                out_leaf = to_shared(taproot::leaf_hash(control.version(),
-                    *out_script));
-
-                // Execute tapleaf script.
-                // out stack  : [stack-elements]
-                // out script : (popped-from-stack)
-                return taproot::verify_commit(control, key, *out_leaf) ?
-                    error::script_success : error::invalid_commitment;
+                out_script = tapleaf;
+                out_leaf = to_shared(leaf);
+                return error::script_success;
             }
 
             // Others remain unencumbered (success).

--- a/test/chain/witness.cpp
+++ b/test/chain/witness.cpp
@@ -113,4 +113,153 @@ BOOST_AUTO_TEST_CASE(witness__annex__moved_not_annex_pattern__empty)
     BOOST_REQUIRE(!instance.annex());
 }
 
+// extract_taproot
+
+// Commitments below are derived from bip340/341 reference math, cross-checked
+// against the bip341 wallet test vectors. Each commits the same internal key
+// (d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d) to the
+// same single op leaf script (op_1), varying leaf version and merkle path.
+static const data_chunk tapleaf_script{ 0x51_u8 };
+
+// Leaf version 0xc0 (tapscript), no merkle path, even output key parity.
+static const auto c0_program = base16_chunk("81d6ccecd0da56aafd816eb5548c4aec7342287fe7cdd2781140d2d162f0f88a");
+static const auto c0_control = base16_chunk("c0d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d");
+static const auto c0_tapleaf = base16_array("a85b2107f791b26a84e7586c28cec7cb61202ed3d01944d832500f363782d675");
+
+// Leaf version 0xc2 (undefined), no merkle path, even output key parity.
+static const auto c2_program = base16_chunk("f608ee80bd1b9cf910a33d91a31f2d67ebe8994e2c8ce62dad6697be5d36b334");
+static const auto c2_control = base16_chunk("c2d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d");
+
+// Leaf version 0xc2 (undefined), one merkle node, odd output key parity.
+static const auto c2m_program = base16_chunk("ce5bbc28aaeab2c6285290ab3d172ee0f8923426f126c482592273aece547405");
+static const auto c2m_control = base16_chunk("c3d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961daaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+static script taproot_prevout(const data_chunk& program) NOEXCEPT
+{
+    return script{ script::to_pay_witness_pattern(1_u8, program) };
+}
+
+static chain::witness script_path(const data_chunk& control) NOEXCEPT
+{
+    const auto script_element = to_shared<data_chunk>(tapleaf_script);
+    const auto control_element = to_shared<data_chunk>(control);
+    return chain::witness{ chunk_cptrs{ script_element, control_element } };
+}
+
+BOOST_AUTO_TEST_CASE(witness__extract_taproot__tapscript_committed__success_with_tapleaf)
+{
+    hash_cptr leaf{};
+    script::cptr out{};
+    chunk_cptrs_ptr stack{};
+    const auto prevout = taproot_prevout(c0_program);
+    const auto instance = script_path(c0_control);
+
+    BOOST_REQUIRE_EQUAL(instance.extract_taproot(leaf, out, stack, prevout), error::script_success);
+    BOOST_REQUIRE(leaf);
+    BOOST_REQUIRE_EQUAL(*leaf, c0_tapleaf);
+    BOOST_REQUIRE(*out == script(tapleaf_script, false));
+    BOOST_REQUIRE(!out->is_prevalid());
+    BOOST_REQUIRE(stack->empty());
+}
+
+BOOST_AUTO_TEST_CASE(witness__extract_taproot__tapscript_uncommitted__invalid_commitment)
+{
+    hash_cptr leaf{};
+    script::cptr out{};
+    chunk_cptrs_ptr stack{};
+    const auto prevout = taproot_prevout(c2_program);
+    const auto instance = script_path(c0_control);
+
+    BOOST_REQUIRE_EQUAL(instance.extract_taproot(leaf, out, stack, prevout), error::invalid_commitment);
+}
+
+// The commitment binds all leaf versions, so an undefined version is not
+// unencumbered until its control block commits to the output key [bip341].
+BOOST_AUTO_TEST_CASE(witness__extract_taproot__undefined_leaf_version_committed__success_unencumbered)
+{
+    hash_cptr leaf{};
+    script::cptr out{};
+    chunk_cptrs_ptr stack{};
+    const auto prevout = taproot_prevout(c2_program);
+    const auto instance = script_path(c2_control);
+
+    BOOST_REQUIRE_EQUAL(instance.extract_taproot(leaf, out, stack, prevout), error::script_success);
+    BOOST_REQUIRE(!leaf);
+    BOOST_REQUIRE(out->is_prevalid());
+    BOOST_REQUIRE(stack->empty());
+}
+
+BOOST_AUTO_TEST_CASE(witness__extract_taproot__undefined_leaf_version_uncommitted__invalid_commitment)
+{
+    hash_cptr leaf{};
+    script::cptr out{};
+    chunk_cptrs_ptr stack{};
+    const auto prevout = taproot_prevout(c0_program);
+    const auto instance = script_path(c2_control);
+
+    BOOST_REQUIRE_EQUAL(instance.extract_taproot(leaf, out, stack, prevout), error::invalid_commitment);
+}
+
+BOOST_AUTO_TEST_CASE(witness__extract_taproot__undefined_leaf_version_merkle_path_committed__success_unencumbered)
+{
+    hash_cptr leaf{};
+    script::cptr out{};
+    chunk_cptrs_ptr stack{};
+    const auto prevout = taproot_prevout(c2m_program);
+    const auto instance = script_path(c2m_control);
+
+    BOOST_REQUIRE_EQUAL(instance.extract_taproot(leaf, out, stack, prevout), error::script_success);
+    BOOST_REQUIRE(!leaf);
+    BOOST_REQUIRE(out->is_prevalid());
+    BOOST_REQUIRE(stack->empty());
+}
+
+BOOST_AUTO_TEST_CASE(witness__extract_taproot__undefined_leaf_version_merkle_path_uncommitted__invalid_commitment)
+{
+    hash_cptr leaf{};
+    script::cptr out{};
+    chunk_cptrs_ptr stack{};
+    const auto prevout = taproot_prevout(c2_program);
+    const auto instance = script_path(c2m_control);
+
+    BOOST_REQUIRE_EQUAL(instance.extract_taproot(leaf, out, stack, prevout), error::invalid_commitment);
+}
+
+BOOST_AUTO_TEST_CASE(witness__extract_taproot__control_size_underflow__invalid_witness)
+{
+    hash_cptr leaf{};
+    script::cptr out{};
+    chunk_cptrs_ptr stack{};
+    const auto prevout = taproot_prevout(c2_program);
+    const auto instance = script_path(data_chunk(ec_xonly_size, 0xc2_u8));
+
+    BOOST_REQUIRE_EQUAL(instance.extract_taproot(leaf, out, stack, prevout), error::invalid_witness);
+}
+
+BOOST_AUTO_TEST_CASE(witness__extract_taproot__control_size_not_multiple__invalid_witness)
+{
+    hash_cptr leaf{};
+    script::cptr out{};
+    chunk_cptrs_ptr stack{};
+    const auto prevout = taproot_prevout(c2_program);
+    const auto instance = script_path(data_chunk(ec_xonly_size + 2_size, 0xc2_u8));
+
+    BOOST_REQUIRE_EQUAL(instance.extract_taproot(leaf, out, stack, prevout), error::invalid_witness);
+}
+
+BOOST_AUTO_TEST_CASE(witness__extract_taproot__key_path__success_with_checksig)
+{
+    hash_cptr leaf{};
+    script::cptr out{};
+    chunk_cptrs_ptr stack{};
+    const auto prevout = taproot_prevout(c0_program);
+    const chain::witness instance{ chunk_cptrs{ to_shared<data_chunk>({ 0x24_u8 }) } };
+
+    BOOST_REQUIRE_EQUAL(instance.extract_taproot(leaf, out, stack, prevout), error::script_success);
+    BOOST_REQUIRE(!leaf);
+    BOOST_REQUIRE(*out == script{ { { opcode::checksig } } });
+    BOOST_REQUIRE_EQUAL(stack->size(), two);
+    BOOST_REQUIRE_EQUAL(*stack->back(), c0_program);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
extract_taproot() branched on the control block leaf version before checking the commitment to the output key, so a script path spend with any leaf version other than 0xc0 returned success without proving any commitment at all. BIP341 orders these the other way around: the tapleaf hash, the merkle path and the "fail if q != x(Q) or c[0] & 1 != y(Q) mod 2" test all precede the leaf version branch, as in Core's VerifyWitnessProgram.

Every 32-byte v1 program was therefore spendable by anyone, with the witness <anything> <anything> <0xc2 || 32 arbitrary bytes>. This accepts invalid blocks rather than rejecting valid ones, so it is chain splitting.

Compute the tapleaf hash and verify the commitment for every leaf version, then branch: 0xc0 executes the tapscript, other versions remain unencumbered as before.