### PR TITLE
fix: 3 tapscript consensus divergences from BIP341/342

### DIFF
--- a/include/bitcoin/system/impl/machine/interpreter.ipp
+++ b/include/bitcoin/system/impl/machine/interpreter.ipp
@@ -1162,6 +1162,10 @@ op_check_multisig_verify() NOEXCEPT
     const auto subscript = this->subscript(endorsements);
     const auto bip66 = this->is_enabled(flags::bip66_rule);
 
+    // This subscript is stripped of these endorsements, so a hash cached by a
+    // previous signature op (with a different subscript) cannot be reused.
+    this->uncache();
+
     // Keys may be empty.
     for (const auto& key: keys)
     {

--- a/include/bitcoin/system/impl/machine/interpreter.ipp
+++ b/include/bitcoin/system/impl/machine/interpreter.ipp
@@ -227,7 +227,7 @@ op_return() const NOEXCEPT
 {
     if (this->is_enabled(flags::nops_rule))
         return op_unevaluated(opcode::op_return);
-        
+
     return error::op_not_implemented;
 }
 
@@ -439,7 +439,7 @@ op_roll() NOEXCEPT
 {
     size_t index;
 
-    // 998,[0,1,2,...,997,998,999] => {998} [0,1,2,...,997,998,999] 
+    // 998,[0,1,2,...,997,998,999] => {998} [0,1,2,...,997,998,999]
     if (!this->pop_index32(index))
         return error::op_roll;
 
@@ -821,7 +821,7 @@ op_num_equal_verify() NOEXCEPT
     if (!this->pop_binary32(left, right))
         return error::op_num_equal_verify1;
 
-    return (left == right) ? error::op_success : 
+    return (left == right) ? error::op_success :
         error::op_num_equal_verify2;
 }
 
@@ -1316,24 +1316,23 @@ op_check_sig_add() NOEXCEPT
         return error::op_success;
     }
 
-    // Split endorsement into schnorr signature and signature hash flags.
-    uint8_t sighash_flags;
-    const auto& sig = this->schnorr_split(sighash_flags, *endorsement);
-    if (sighash_flags == chain::coverage::invalid)
-        return error::op_check_sig_add4;
+    if (key->size() == ec_xonly_size)
+    {
+        // Split endorsement into schnorr signature and signature hash flags.
+        uint8_t sighash_flags;
+        const auto& sig = this->schnorr_split(sighash_flags, *endorsement);
+        if (sighash_flags == chain::coverage::invalid)
+            return error::op_check_sig_add4;
 
-    // Signature hash caching (bypass signature hash if same as previous).
-    if (!this->cached(sighash_flags))
-        if (!this->set_hash(sighash_flags))
-            return error::op_check_sig_add5;
+        // Signature hash caching (bypass signature hash if same as previous).
+        if (!this->cached(sighash_flags))
+            if (!this->set_hash(sighash_flags))
+                return error::op_check_sig_add5;
 
-    // Verify schnorr signature against public key and signature hash.
-    // If public key size is neither 0 nor 32 bytes, it is an unknown type.
-    // During script execution of signature opcodes these behave exactly as
-    // known types except that signature validation considered successful.
-    if (key->size() == ec_xonly_size &&
-        !this->verify_schnorr_signature(*key, this->cached_hash(), sig))
+        // Verify schnorr signature against public key and signature hash.
+        if (!this->verify_schnorr_signature(*key, this->cached_hash(), sig))
             return error::op_check_sig_add6;
+    }
 
     // If signature not empty, opcode counted toward sigops budget.
     if (!this->sigops_increment())

--- a/include/bitcoin/system/impl/machine/program_construct.ipp
+++ b/include/bitcoin/system/impl/machine/program_construct.ipp
@@ -129,7 +129,7 @@ CLASS::program(const transaction& tx, const input_iterator& input,
     primary_(projection<Stack>(*witness)),
     budget_(ceilinged_add(
         add1(chain::signature_cost),
-        chain::witness::serialized_size(*witness_, true)))
+        (*input)->witness().serialized_size(true)))
 {
     script_->clear_offset();
 }

--- a/include/bitcoin/system/impl/machine/program_verify.ipp
+++ b/include/bitcoin/system/impl/machine/program_verify.ipp
@@ -132,6 +132,9 @@ set_subscript(const op_iterator& op) NOEXCEPT
     // Advance the offset to the op following the found code separator.
     // This is non-const because changes script state (despite being mutable).
     script_->offset = std::next(op);
+
+    // The subscript is changed, so any cached signature hash is stale.
+    uncache();
 }
 
 // static/private
@@ -229,11 +232,24 @@ signature_hash(hash_digest& out, const script& subscript,
 // Multisig signature hash caching.
 // ----------------------------------------------------------------------------
 
+// ****************************************************************************
+// CONSENSUS: The cache is keyed only on sighash flags, so it is valid only
+// while the subscript is unchanged. A v1 signature hash commits to the
+// op_codeseparator position and a v0 subscript is stripped of the endorsements
+// of the op that created it, so both invalidate the cache.
+// ****************************************************************************
 TEMPLATE
 INLINE bool CLASS::
 cached(uint8_t sighash_flags) const NOEXCEPT
 {
     return multisig_.set && (multisig_.flags == sighash_flags);
+}
+
+TEMPLATE
+INLINE void CLASS::
+uncache() const NOEXCEPT
+{
+    multisig_.set = false;
 }
 
 TEMPLATE

--- a/include/bitcoin/system/machine/program.hpp
+++ b/include/bitcoin/system/machine/program.hpp
@@ -198,6 +198,7 @@ protected:
     /// Multisig signature hash caching.
     /// -----------------------------------------------------------------------
     virtual INLINE bool cached(uint8_t sighash_flags) const NOEXCEPT;
+    virtual INLINE void uncache() const NOEXCEPT;
     virtual INLINE const hash_digest& cached_hash() const NOEXCEPT;
     virtual INLINE bool set_hash(uint8_t sighash_flags) const NOEXCEPT;
     virtual INLINE void set_hash(const chain::script& subscript,

--- a/test/machine/interpreter.cpp
+++ b/test/machine/interpreter.cpp
@@ -126,4 +126,83 @@ BOOST_AUTO_TEST_CASE(interpreter__run__tapscript_budget_exceeded__op_check_sig_b
     BOOST_REQUIRE_EQUAL(run_budget_script(7), error::op_check_sig_budget);
 }
 
+namespace {
+
+// <sig> <0> <key> OP_CHECKSIGADD <1> OP_NUMEQUAL.
+// Success pushes number+1, so the script is true only when the sigop passed.
+script to_checksigadd_script(const data_chunk& key, const data_chunk& endorsement) NOEXCEPT
+{
+    operations ops{};
+    ops.emplace_back(endorsement, false);
+    ops.emplace_back(opcode::push_size_0);
+    ops.emplace_back(key, false);
+    ops.emplace_back(opcode::checksigadd);
+    ops.emplace_back(opcode::push_positive_1);
+    ops.emplace_back(opcode::numequal);
+    return script{ std::move(ops) };
+}
+
+// 64 bytes plus an undefined sighash byte (zero must be implicit) [bip341].
+data_chunk to_undefined_sighash_endorsement() NOEXCEPT
+{
+    data_chunk endorsement(add1(ec_signature_size), 0x11);
+    endorsement.back() = 0x04;
+    return endorsement;
+}
+
+} // namespace
+
+// An endorsement of neither 64 nor 65 bytes is not a schnorr signature, but
+// with an unknown key type it is never parsed, so the sigop passes.
+BOOST_AUTO_TEST_CASE(interpreter__run__checksigadd_unknown_key_unparsable_endorsement__success)
+{
+    const data_chunk endorsement(10, 0x11);
+    const auto leaf = to_checksigadd_script(unknown_key, endorsement);
+    BOOST_REQUIRE_EQUAL(run_tapscript(leaf), error::script_success);
+}
+
+// Likewise an undefined sighash byte does not encumber an unknown key type.
+BOOST_AUTO_TEST_CASE(interpreter__run__checksigadd_unknown_key_undefined_sighash__success)
+{
+    const auto endorsement = to_undefined_sighash_endorsement();
+    const auto leaf = to_checksigadd_script(unknown_key, endorsement);
+    BOOST_REQUIRE_EQUAL(run_tapscript(leaf), error::script_success);
+}
+
+// An empty key is invalid for any endorsement [bip342].
+BOOST_AUTO_TEST_CASE(interpreter__run__checksigadd_empty_key__op_check_sig_add2)
+{
+    const data_chunk key{};
+    const data_chunk endorsement(10, 0x11);
+    const auto leaf = to_checksigadd_script(key, endorsement);
+    BOOST_REQUIRE_EQUAL(run_tapscript(leaf), error::op_check_sig_add2);
+}
+
+// A 32 byte key remains subject to endorsement parsing.
+BOOST_AUTO_TEST_CASE(interpreter__run__checksigadd_xonly_key_unparsable_endorsement__op_check_sig_add4)
+{
+    const data_chunk key(ec_xonly_size, 0x02);
+    const data_chunk endorsement(10, 0x11);
+    const auto leaf = to_checksigadd_script(key, endorsement);
+    BOOST_REQUIRE_EQUAL(run_tapscript(leaf), error::op_check_sig_add4);
+}
+
+// A 32 byte key remains subject to the defined sighash type rule.
+BOOST_AUTO_TEST_CASE(interpreter__run__checksigadd_xonly_key_undefined_sighash__op_check_sig_add4)
+{
+    const data_chunk key(ec_xonly_size, 0x02);
+    const auto endorsement = to_undefined_sighash_endorsement();
+    const auto leaf = to_checksigadd_script(key, endorsement);
+    BOOST_REQUIRE_EQUAL(run_tapscript(leaf), error::op_check_sig_add4);
+}
+
+// A 32 byte key remains subject to signature verification.
+BOOST_AUTO_TEST_CASE(interpreter__run__checksigadd_xonly_key_invalid_signature__op_check_sig_add6)
+{
+    const data_chunk key(ec_xonly_size, 0x02);
+    const data_chunk endorsement(ec_signature_size, 0x11);
+    const auto leaf = to_checksigadd_script(key, endorsement);
+    BOOST_REQUIRE_EQUAL(run_tapscript(leaf), error::op_check_sig_add6);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/machine/interpreter.cpp
+++ b/test/machine/interpreter.cpp
@@ -23,11 +23,6 @@ BOOST_AUTO_TEST_SUITE(interpreter_tests)
 using namespace system::chain;
 using namespace system::machine;
 
-BOOST_AUTO_TEST_CASE(interpreter_test)
-{
-    BOOST_REQUIRE(true);
-}
-
 namespace {
 
 constexpr auto taproot_rules = flags::bip141_rule | flags::bip143_rule | flags::bip341_rule | flags::bip342_rule;
@@ -203,6 +198,82 @@ BOOST_AUTO_TEST_CASE(interpreter__run__checksigadd_xonly_key_invalid_signature__
     const data_chunk endorsement(ec_signature_size, 0x11);
     const auto leaf = to_checksigadd_script(key, endorsement);
     BOOST_REQUIRE_EQUAL(run_tapscript(leaf), error::op_check_sig_add6);
+}
+
+namespace {
+
+// OP_0 <key> OP_CHECKSIGADD OP_DROP OP_CODESEPARATOR OP_0 <key> OP_CHECKSIGADD
+// Both sigops take their signature from the witness. The second signs over the
+// codeseparator position of 4, the first over none (0xffffffff). The offset is
+// the op following the codeseparator, from which that position is derived.
+constexpr size_t after_codeseparator = 5;
+
+script to_codeseparator_script(const ec_xonly& key) NOEXCEPT
+{
+    const data_chunk point{ key.begin(), key.end() };
+
+    operations ops{};
+    ops.emplace_back(opcode::push_size_0);
+    ops.emplace_back(point, false);
+    ops.emplace_back(opcode::checksigadd);
+    ops.emplace_back(opcode::drop);
+    ops.emplace_back(opcode::codeseparator);
+    ops.emplace_back(opcode::push_size_0);
+    ops.emplace_back(point, false);
+    ops.emplace_back(opcode::checksigadd);
+    return script{ std::move(ops) };
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(interpreter__run__tapscript_codeseparator_signature_hash__success)
+{
+    // Any valid secret, with its bip340 x-only point.
+    const auto secret = base16_hash("b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    ec_compressed compressed{};
+    BOOST_REQUIRE(secret_to_public(compressed, secret));
+
+    const auto x_only = std::next(compressed.data());
+    const auto key = unsafe_array_cast<uint8_t, ec_xonly_size>(x_only);
+    const auto leaf = to_codeseparator_script(key);
+    const auto tapleaf = to_shared(taproot::leaf_hash(tapscript_version, leaf));
+    constexpr auto version = script_version::taproot;
+    constexpr auto sighash = coverage::hash_default;
+
+    // The signature hash is taken over a tx without the signatures, which it
+    // does not cover, and is identical to that of the tx that carries them.
+    const auto tx = to_spending_transaction({});
+    const auto in = tx.inputs_ptr()->begin();
+
+    // The first sigop executes before any codeseparator.
+    hash_digest first{};
+    leaf.clear_offset();
+    BOOST_REQUIRE(tx.signature_hash(first, in, leaf, prevout_value, tapleaf, version, sighash, taproot_rules));
+
+    // The second executes after the codeseparator, which the interpreter
+    // records by advancing the offset to the op following it.
+    hash_digest second{};
+    leaf.offset = std::next(leaf.ops().begin(), after_codeseparator);
+    BOOST_REQUIRE(tx.signature_hash(second, in, leaf, prevout_value, tapleaf, version, sighash, taproot_rules));
+    leaf.clear_offset();
+
+    // The codeseparator position is the only difference between them.
+    BOOST_REQUIRE_NE(first, second);
+
+    // Sign each with the implied SIGHASH_DEFAULT (64 byte, no sighash byte).
+    ec_signature first_signature{};
+    ec_signature second_signature{};
+    BOOST_REQUIRE(schnorr::sign(first_signature, secret, first, one_hash));
+    BOOST_REQUIRE(schnorr::sign(second_signature, secret, second, one_hash));
+
+    // Witness elements, the last of which is the top of the execution stack.
+    const data_chunk second_chunk{ second_signature.begin(), second_signature.end() };
+    const data_chunk first_chunk{ first_signature.begin(), first_signature.end() };
+    const chunk_cptrs elements{ to_shared<data_chunk>(second_chunk), to_shared<data_chunk>(first_chunk) };
+
+    // Both signatures verify only if the second sigop takes its own hash. A
+    // cache retained across the codeseparator hands it the first instead.
+    BOOST_REQUIRE_EQUAL(run_tapscript(leaf, elements), error::script_success);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/machine/interpreter.cpp
+++ b/test/machine/interpreter.cpp
@@ -20,9 +20,110 @@
 
 BOOST_AUTO_TEST_SUITE(interpreter_tests)
 
+using namespace system::chain;
+using namespace system::machine;
+
 BOOST_AUTO_TEST_CASE(interpreter_test)
 {
     BOOST_REQUIRE(true);
+}
+
+namespace {
+
+constexpr auto taproot_rules = flags::bip141_rule | flags::bip143_rule | flags::bip341_rule | flags::bip342_rule;
+constexpr uint64_t prevout_value = 42u;
+
+// A non-empty signature charges the budget. A key that is neither empty nor
+// 32 bytes is an unknown (upgradable) type, for which signature validation is
+// considered successful, so no valid signature is required here [bip342].
+const data_chunk dummy_signature{ 0x01 };
+const data_chunk unknown_key(add1(ec_xonly_size), 0x02);
+
+// <sig> <key> OP_CHECKSIGVERIFY per sigop (37 bytes each), then OP_1.
+script to_budget_script(size_t sigops) NOEXCEPT
+{
+    operations ops{};
+    for (size_t sigop{}; sigop < sigops; ++sigop)
+    {
+        ops.emplace_back(dummy_signature, false);
+        ops.emplace_back(unknown_key, false);
+        ops.emplace_back(opcode::checksigverify);
+    }
+
+    ops.emplace_back(opcode::push_positive_1);
+    return script{ std::move(ops) };
+}
+
+// The tx spending the tapscript. The signature hash does not cover the witness
+// (apart from an annex), so a tx built with an empty witness produces the same
+// hashes as one carrying the signatures over which those hashes are taken.
+transaction to_spending_transaction(const chunk_cptrs& stack) NOEXCEPT
+{
+    // A non-null point, so the tx is not taken for a coinbase.
+    const point outpoint{ one_hash, 0u };
+    const witness spender{ stack };
+    const chain::inputs ins{ input{ outpoint, script{}, spender, 0xffffffff } };
+    const chain::outputs outs{ output{ prevout_value, script{} } };
+    const transaction tx{ 1u, ins, outs, 0u };
+
+    const auto prevout = to_shared<output>(output{ prevout_value, script{} });
+    tx.inputs_ptr()->front()->prevout = prevout;
+    return tx;
+}
+
+// Run a tapscript exactly as connect_witness does: the input carries the full
+// witness, while the program is handed the stack with the control block and
+// leaf script already popped. Elements are the witness stack-elements, in
+// witness order (the last is the top of the execution stack).
+code run_tapscript(const script& leaf, const chunk_cptrs& elements={}) NOEXCEPT
+{
+    // Witness of the input: [elements] <script> <control>.
+    const data_chunk control(add1(ec_xonly_size), tapscript_version);
+    auto stack = elements;
+    stack.push_back(to_shared<data_chunk>(leaf.to_data(false)));
+    stack.push_back(to_shared<data_chunk>(control));
+
+    const auto tx = to_spending_transaction(stack);
+    const auto in = tx.inputs_ptr()->begin();
+
+    // Execution stack is the witness less the control block and leaf script.
+    const auto execution = std::make_shared<chunk_cptrs>(elements);
+    const auto tapleaf = to_shared(taproot::leaf_hash(tapscript_version, leaf));
+    const auto leaf_ptr = to_shared<script>(leaf);
+    const signatures capture{};
+    constexpr auto version = script_version::taproot;
+
+    interpreter<contiguous_stack> program{ tx, in, leaf_ptr, taproot_rules, version, execution, tapleaf, capture };
+    return program.run();
+}
+
+code run_budget_script(size_t sigops) NOEXCEPT
+{
+    return run_tapscript(to_budget_script(sigops));
+}
+
+} // namespace
+
+// Two sigops against a 75 byte leaf script. The full witness serializes to 111
+// bytes, so the budget is 162 and two sigops (100) fit. Deriving the budget
+// from the empty execution stack instead yields 51, which stops at one sigop.
+BOOST_AUTO_TEST_CASE(interpreter__run__tapscript_budget_from_full_witness__success)
+{
+    BOOST_REQUIRE_EQUAL(run_budget_script(2), error::script_success);
+}
+
+// Six sigops (300) still fit a 223 byte leaf script, whose witness serializes
+// to 259 bytes for a budget of 310.
+BOOST_AUTO_TEST_CASE(interpreter__run__tapscript_budget_at_limit__success)
+{
+    BOOST_REQUIRE_EQUAL(run_budget_script(6), error::script_success);
+}
+
+// Seven sigops (350) exceed the 349 budget of a 260 byte leaf script, whose
+// witness serializes to 298 bytes. The budget remains enforced.
+BOOST_AUTO_TEST_CASE(interpreter__run__tapscript_budget_exceeded__op_check_sig_budget)
+{
+    BOOST_REQUIRE_EQUAL(run_budget_script(7), error::op_check_sig_budget);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Follow-up to #1927, which fixed the missing taproot commitment check for unknown leaf versions. The same review surfaced three further divergences between tapscript execution and BIP341/342. Each is a separate commit with tests (asked an LLM to help with the tests btw).

1. Sigop budget derived from the wrong witness
2. `OP_CHECKSIGADD` parsed the endorsement for unknown public key types
3. Signature hash cache not invalidated when the subscript changes