### PR TITLE
Require canonical scriptSig push for p2sh-wrapped witness spends

### DIFF
--- a/include/bitcoin/system/chain/script.hpp
+++ b/include/bitcoin/system/chain/script.hpp
@@ -47,6 +47,7 @@ public:
     static constexpr bool is_enabled(uint32_t active_flags, flags flag) NOEXCEPT;
     static constexpr bool is_push_only_pattern(const operations& ops) NOEXCEPT;
     static constexpr bool is_relaxed_push_pattern(const operations& ops) NOEXCEPT;
+    static constexpr bool is_nominal_push_pattern(const operations& ops) NOEXCEPT;
     static constexpr bool is_commitment_pattern(const operations& ops) NOEXCEPT;
     static constexpr bool is_witness_program_pattern(const operations& ops) NOEXCEPT;
     static constexpr bool is_anchor_program_pattern(const operations& ops) NOEXCEPT;

--- a/include/bitcoin/system/error/script_error_t.hpp
+++ b/include/bitcoin/system/error/script_error_t.hpp
@@ -49,6 +49,7 @@ enum script_error_t : uint8_t
     invalid_witness_stack,
     invalid_commitment,
     dirty_witness,
+    dirty_embed,
     stack_false,
 
     // chained to op_error_t

--- a/include/bitcoin/system/impl/chain/script_patterns.ipp
+++ b/include/bitcoin/system/impl/chain/script_patterns.ipp
@@ -69,6 +69,13 @@ constexpr bool script::is_relaxed_push_pattern(const operations& ops) NOEXCEPT
     return std::all_of(ops.begin(), ops.end(), push);
 }
 
+// A single push has exactly one nominal encoding [bip141].
+constexpr bool script::is_nominal_push_pattern(const operations& ops) NOEXCEPT
+{
+    return is_one(ops.size())
+        && ops[0].is_nominal_push();
+}
+
 // ****************************************************************************
 // CONSENSUS: this pattern is used to commit to bip141 witness data.
 // ****************************************************************************

--- a/include/bitcoin/system/impl/machine/interpreter_connect.ipp
+++ b/include/bitcoin/system/impl/machine/interpreter_connect.ipp
@@ -104,9 +104,10 @@ code CLASS::connect_embedded(const chain::context& state,
 {
     using namespace chain;
     const auto& input = **it;
+    const auto& ops = input.script().ops();
 
     // Input script is limited to relaxed push data operations [bip16].
-    if (!script::is_relaxed_push_pattern(input.script().ops()))
+    if (!script::is_relaxed_push_pattern(ops))
         return error::invalid_script_embed;
 
     // Embedded script must be at the top of the stack [bip16].
@@ -124,15 +125,9 @@ code CLASS::connect_embedded(const chain::context& state,
     }
     else if (embedded->is_pay_to_witness(state.flags))
     {
-        // ********************************************************************
-        // CONSENSUS: The input script must be *exactly* a canonical push of
-        // the embedded script, otherwise the witness is malleable [bip141].
-        // A single relaxed push (e.g. push_one_size) encodes the same data
-        // yet is a distinct script, so the nominal encoding is required.
-        // ********************************************************************
-        const auto& ops = input.script().ops();
-        if (!is_one(ops.size()) || !ops.front().is_nominal_push())
-            return error::dirty_witness;
+        // The input script must be a nominal push of the embedded [bip141].
+        if (!script::is_nominal_push_pattern(ops))
+            return error::dirty_embed;
 
         // Because output script pushed version/witness program [bip141].
         if ((ec = connect_witness(state, tx, it, *embedded, true, capture)))

--- a/include/bitcoin/system/impl/machine/interpreter_connect.ipp
+++ b/include/bitcoin/system/impl/machine/interpreter_connect.ipp
@@ -124,8 +124,14 @@ code CLASS::connect_embedded(const chain::context& state,
     }
     else if (embedded->is_pay_to_witness(state.flags))
     {
-        // The input script must be a push of the embedded_script [bip141].
-        if (!is_one(input.script().ops().size()))
+        // ********************************************************************
+        // CONSENSUS: The input script must be *exactly* a canonical push of
+        // the embedded script, otherwise the witness is malleable [bip141].
+        // A single relaxed push (e.g. push_one_size) encodes the same data
+        // yet is a distinct script, so the nominal encoding is required.
+        // ********************************************************************
+        const auto& ops = input.script().ops();
+        if (!is_one(ops.size()) || !ops.front().is_nominal_push())
             return error::dirty_witness;
 
         // Because output script pushed version/witness program [bip141].

--- a/src/error/script_error_t.cpp
+++ b/src/error/script_error_t.cpp
@@ -44,6 +44,7 @@ DEFINE_ERROR_T_MESSAGE_MAP(script_error)
     { invalid_witness_stack, "invalid witness stack" },
     { invalid_commitment, "invalid tapscript commitment" },
     { dirty_witness, "dirty witness" },
+    { dirty_embed, "dirty embed" },
     { stack_false, "stack false" }
 };
 

--- a/test/chain/script_connect.cpp
+++ b/test/chain/script_connect.cpp
@@ -447,4 +447,75 @@ BOOST_AUTO_TEST_CASE(script__verify__bip143_no_find_and_delete_tx__success)
     BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip141_rule }, 0), error::op_check_sig_verify4);
 }
 
+// bip141 p2sh-wrapped witness scriptSig malleation.
+// ----------------------------------------------------------------------------
+// The scriptSig of a p2sh-wrapped witness spend must be *exactly* a canonical
+// push of the embedded script. These are the bip143 p2sh_p2wpkh/p2sh_p2wsh
+// transactions above with the scriptSig push re-encoded using a non-nominal
+// (yet still valid) push opcode. The embedded script, and therefore the p2sh
+// hash, is unchanged, and bip143 signature hashing does not commit to the
+// scriptSig, so these would otherwise verify - third party malleation.
+
+BOOST_AUTO_TEST_CASE(script__verify__bip141_p2sh_p2wpkh_pushdata1_scriptsig__dirty_witness)
+{
+    // scriptSig is [push_one_size(0x4c) 0x16 0014<20 bytes>] vs. [0x16 0014<20 bytes>].
+    const auto decoded_tx = base16_chunk("01000000000101db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a547701000000184c16001479091972186c449eb1ded22b78e40d009bdf0089feffffff02b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac0008af2f000000001976a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac02473044022047ac8e878352d3ebbde1c94ce3a10d057c24175747116f8288e5d794d12d482f0220217f36a485cae903c713331d877c1f64677e3622ad4010726870540656fe9dcb012103ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a2687392040000");
+    const transaction_accessor tx(decoded_tx, true);
+    BOOST_REQUIRE(tx.is_valid());
+    BOOST_REQUIRE_EQUAL(tx.inputs_ptr()->size(), 1u);
+
+    // The scriptSig is a single (relaxed) push of the same embedded script.
+    const auto& ops = (*tx.inputs_ptr())[0]->script().ops();
+    BOOST_REQUIRE_EQUAL(ops.size(), 1u);
+    BOOST_REQUIRE(ops.front().code() == opcode::push_one_size);
+    BOOST_REQUIRE_EQUAL(encode_base16(ops.front().data()), "001479091972186c449eb1ded22b78e40d009bdf0089");
+
+    constexpr auto value = 1000000000u;
+    (*tx.inputs_ptr())[0]->prevout = to_shared(output{ value, { base16_chunk("a9144733f37cf4db86fbc2efed2500b4f4e49f31202387"), false } });
+
+    // The p2sh hash still matches, and bip143 does not sign the scriptSig.
+    BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip141_rule | flags::bip143_rule }, 0), error::dirty_witness);
+}
+
+BOOST_AUTO_TEST_CASE(script__verify__bip141_p2sh_p2wpkh_pushdata2_scriptsig__dirty_witness)
+{
+    // scriptSig is [push_two_size(0x4d) 0x1600 0014<20 bytes>].
+    const auto decoded_tx = base16_chunk("01000000000101db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a547701000000194d1600001479091972186c449eb1ded22b78e40d009bdf0089feffffff02b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac0008af2f000000001976a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac02473044022047ac8e878352d3ebbde1c94ce3a10d057c24175747116f8288e5d794d12d482f0220217f36a485cae903c713331d877c1f64677e3622ad4010726870540656fe9dcb012103ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a2687392040000");
+    const transaction_accessor tx(decoded_tx, true);
+    BOOST_REQUIRE(tx.is_valid());
+    BOOST_REQUIRE_EQUAL(tx.inputs_ptr()->size(), 1u);
+
+    const auto& ops = (*tx.inputs_ptr())[0]->script().ops();
+    BOOST_REQUIRE_EQUAL(ops.size(), 1u);
+    BOOST_REQUIRE(ops.front().code() == opcode::push_two_size);
+
+    constexpr auto value = 1000000000u;
+    (*tx.inputs_ptr())[0]->prevout = to_shared(output{ value, { base16_chunk("a9144733f37cf4db86fbc2efed2500b4f4e49f31202387"), false } });
+
+    BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip141_rule | flags::bip143_rule }, 0), error::dirty_witness);
+
+    // Without bip141 the embedded script is not a witness program, so the
+    // (unconsumed) witness is what invalidates the input.
+    BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip143_rule }, 0), error::unexpected_witness);
+}
+
+BOOST_AUTO_TEST_CASE(script__verify__bip141_p2sh_p2wsh_pushdata1_scriptsig__dirty_witness)
+{
+    // scriptSig is [push_one_size(0x4c) 0x22 0020<32 bytes>] vs. [0x22 0020<32 bytes>].
+    const auto decoded_tx = base16_chunk("0100000000010136641869ca081e70f394c6948e8af409e18b619df2ed74aa106c1ca29787b96e01000000244c220020a16b5755f7f6f96dbd65f5f0d6ab9418b89af4b1f14a1bb8a09062c35f0dcb54ffffffff0200e9a435000000001976a914389ffce9cd9ae88dcc0631e88a821ffdbe9bfe2688acc0832f05000000001976a9147480a33f950689af511e6e84c138dbbd3c3ee41588ac080047304402206ac44d672dac41f9b00e28f4df20c52eeb087207e8d758d76d92c6fab3b73e2b0220367750dbbe19290069cba53d096f44530e4f98acaa594810388cf7409a1870ce01473044022068c7946a43232757cbdf9176f009a928e1cd9a1a8c212f15c1e11ac9f2925d9002205b75f937ff2f9f3c1246e547e54f62e027f64eefa2695578cc6432cdabce271502473044022059ebf56d98010a932cf8ecfec54c48e6139ed6adb0728c09cbe1e4fa0915302e022007cd986c8fa870ff5d2b3a89139c9fe7e499259875357e20fcbb15571c76795403483045022100fbefd94bd0a488d50b79102b5dad4ab6ced30c4069f1eaa69a4b5a763414067e02203156c6a5c9cf88f91265f5a942e96213afae16d83321c8b31bb342142a14d16381483045022100a5263ea0553ba89221984bd7f0b13613db16e7a70c549a86de0cc0444141a407022005c360ef0ae5a5d4f9f2f87a56c1546cc8268cab08c73501d6b3be2e1e1a8a08824730440220525406a1482936d5a21888260dc165497a90a15669636d8edca6b9fe490d309c022032af0c646a34a44d1f4576bf6a4a74b67940f8faa84c7df9abe12a01a11e2b4783cf56210307b8ae49ac90a048e9b53357a2354b3334e9c8bee813ecb98e99a7e07e8c3ba32103b28f0c28bfab54554ae8c658ac5c3e0ce6e79ad336331f78c428dd43eea8449b21034b8113d703413d57761b8b9781957b8c0ac1dfe69f492580ca4195f50376ba4a21033400f6afecb833092a9a21cfdf1ed1376e58c5d1f47de74683123987e967a8f42103a6d48b1131e94ba04d9737d61acdaa1322008af9602b3b14862c07a1789aac162102d8b661b0b3302ee2f162b09e07a55ad5dfbe673a9f01d9f0c19617681024306b56ae00000000");
+    const transaction_accessor tx(decoded_tx, true);
+    BOOST_REQUIRE(tx.is_valid());
+    BOOST_REQUIRE_EQUAL(tx.inputs_ptr()->size(), 1u);
+
+    const auto& ops = (*tx.inputs_ptr())[0]->script().ops();
+    BOOST_REQUIRE_EQUAL(ops.size(), 1u);
+    BOOST_REQUIRE(ops.front().code() == opcode::push_one_size);
+    BOOST_REQUIRE_EQUAL(encode_base16(ops.front().data()), "0020a16b5755f7f6f96dbd65f5f0d6ab9418b89af4b1f14a1bb8a09062c35f0dcb54");
+
+    constexpr auto value = 987654321u;
+    (*tx.inputs_ptr())[0]->prevout = to_shared(output{ value, { base16_chunk("a9149993a429037b5d912407a71c252019287b8d27a587"), false } });
+
+    BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip141_rule | flags::bip143_rule }, 0), error::dirty_witness);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/chain/script_connect.cpp
+++ b/test/chain/script_connect.cpp
@@ -447,24 +447,14 @@ BOOST_AUTO_TEST_CASE(script__verify__bip143_no_find_and_delete_tx__success)
     BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip141_rule }, 0), error::op_check_sig_verify4);
 }
 
-// bip141 p2sh-wrapped witness scriptSig malleation.
-// ----------------------------------------------------------------------------
-// The scriptSig of a p2sh-wrapped witness spend must be *exactly* a canonical
-// push of the embedded script. These are the bip143 p2sh_p2wpkh/p2sh_p2wsh
-// transactions above with the scriptSig push re-encoded using a non-nominal
-// (yet still valid) push opcode. The embedded script, and therefore the p2sh
-// hash, is unchanged, and bip143 signature hashing does not commit to the
-// scriptSig, so these would otherwise verify - third party malleation.
-
-BOOST_AUTO_TEST_CASE(script__verify__bip141_p2sh_p2wpkh_pushdata1_scriptsig__dirty_witness)
+BOOST_AUTO_TEST_CASE(script__verify__bip141_p2sh_p2wpkh_push_one_size_input__dirty_embed)
 {
-    // scriptSig is [push_one_size(0x4c) 0x16 0014<20 bytes>] vs. [0x16 0014<20 bytes>].
+    // Input script is [push_one_size(0x4c) 0x16 0014<20 bytes>] vs. [0x16 0014<20 bytes>].
     const auto decoded_tx = base16_chunk("01000000000101db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a547701000000184c16001479091972186c449eb1ded22b78e40d009bdf0089feffffff02b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac0008af2f000000001976a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac02473044022047ac8e878352d3ebbde1c94ce3a10d057c24175747116f8288e5d794d12d482f0220217f36a485cae903c713331d877c1f64677e3622ad4010726870540656fe9dcb012103ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a2687392040000");
     const transaction_accessor tx(decoded_tx, true);
     BOOST_REQUIRE(tx.is_valid());
     BOOST_REQUIRE_EQUAL(tx.inputs_ptr()->size(), 1u);
 
-    // The scriptSig is a single (relaxed) push of the same embedded script.
     const auto& ops = (*tx.inputs_ptr())[0]->script().ops();
     BOOST_REQUIRE_EQUAL(ops.size(), 1u);
     BOOST_REQUIRE(ops.front().code() == opcode::push_one_size);
@@ -473,13 +463,12 @@ BOOST_AUTO_TEST_CASE(script__verify__bip141_p2sh_p2wpkh_pushdata1_scriptsig__dir
     constexpr auto value = 1000000000u;
     (*tx.inputs_ptr())[0]->prevout = to_shared(output{ value, { base16_chunk("a9144733f37cf4db86fbc2efed2500b4f4e49f31202387"), false } });
 
-    // The p2sh hash still matches, and bip143 does not sign the scriptSig.
-    BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip141_rule | flags::bip143_rule }, 0), error::dirty_witness);
+    BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip141_rule | flags::bip143_rule }, 0), error::dirty_embed);
 }
 
-BOOST_AUTO_TEST_CASE(script__verify__bip141_p2sh_p2wpkh_pushdata2_scriptsig__dirty_witness)
+BOOST_AUTO_TEST_CASE(script__verify__bip141_p2sh_p2wpkh_push_two_size_input__dirty_embed)
 {
-    // scriptSig is [push_two_size(0x4d) 0x1600 0014<20 bytes>].
+    // Input script is [push_two_size(0x4d) 0x1600 0014<20 bytes>].
     const auto decoded_tx = base16_chunk("01000000000101db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a547701000000194d1600001479091972186c449eb1ded22b78e40d009bdf0089feffffff02b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac0008af2f000000001976a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac02473044022047ac8e878352d3ebbde1c94ce3a10d057c24175747116f8288e5d794d12d482f0220217f36a485cae903c713331d877c1f64677e3622ad4010726870540656fe9dcb012103ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a2687392040000");
     const transaction_accessor tx(decoded_tx, true);
     BOOST_REQUIRE(tx.is_valid());
@@ -492,16 +481,34 @@ BOOST_AUTO_TEST_CASE(script__verify__bip141_p2sh_p2wpkh_pushdata2_scriptsig__dir
     constexpr auto value = 1000000000u;
     (*tx.inputs_ptr())[0]->prevout = to_shared(output{ value, { base16_chunk("a9144733f37cf4db86fbc2efed2500b4f4e49f31202387"), false } });
 
-    BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip141_rule | flags::bip143_rule }, 0), error::dirty_witness);
+    BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip141_rule | flags::bip143_rule }, 0), error::dirty_embed);
 
-    // Without bip141 the embedded script is not a witness program, so the
-    // (unconsumed) witness is what invalidates the input.
     BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip143_rule }, 0), error::unexpected_witness);
 }
 
-BOOST_AUTO_TEST_CASE(script__verify__bip141_p2sh_p2wsh_pushdata1_scriptsig__dirty_witness)
+BOOST_AUTO_TEST_CASE(script__verify__bip141_p2sh_p2wpkh_extra_push_input__dirty_embed)
 {
-    // scriptSig is [push_one_size(0x4c) 0x22 0020<32 bytes>] vs. [0x22 0020<32 bytes>].
+    // Input script is [op_0][0x16 0014<20 bytes>] vs. [0x16 0014<20 bytes>].
+    const auto decoded_tx = base16_chunk("01000000000101db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a547701000000180016001479091972186c449eb1ded22b78e40d009bdf0089feffffff02b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac0008af2f000000001976a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac02473044022047ac8e878352d3ebbde1c94ce3a10d057c24175747116f8288e5d794d12d482f0220217f36a485cae903c713331d877c1f64677e3622ad4010726870540656fe9dcb012103ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a2687392040000");
+    const transaction_accessor tx(decoded_tx, true);
+    BOOST_REQUIRE(tx.is_valid());
+    BOOST_REQUIRE_EQUAL(tx.inputs_ptr()->size(), 1u);
+
+    const auto& ops = (*tx.inputs_ptr())[0]->script().ops();
+    BOOST_REQUIRE_EQUAL(ops.size(), 2u);
+    BOOST_REQUIRE(ops.front().code() == opcode::push_size_0);
+    BOOST_REQUIRE(ops.back().is_nominal_push());
+    BOOST_REQUIRE_EQUAL(encode_base16(ops.back().data()), "001479091972186c449eb1ded22b78e40d009bdf0089");
+
+    constexpr auto value = 1000000000u;
+    (*tx.inputs_ptr())[0]->prevout = to_shared(output{ value, { base16_chunk("a9144733f37cf4db86fbc2efed2500b4f4e49f31202387"), false } });
+
+    BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip141_rule | flags::bip143_rule }, 0), error::dirty_embed);
+}
+
+BOOST_AUTO_TEST_CASE(script__verify__bip141_p2sh_p2wsh_push_one_size_input__dirty_embed)
+{
+    // Input script is [push_one_size(0x4c) 0x22 0020<32 bytes>] vs. [0x22 0020<32 bytes>].
     const auto decoded_tx = base16_chunk("0100000000010136641869ca081e70f394c6948e8af409e18b619df2ed74aa106c1ca29787b96e01000000244c220020a16b5755f7f6f96dbd65f5f0d6ab9418b89af4b1f14a1bb8a09062c35f0dcb54ffffffff0200e9a435000000001976a914389ffce9cd9ae88dcc0631e88a821ffdbe9bfe2688acc0832f05000000001976a9147480a33f950689af511e6e84c138dbbd3c3ee41588ac080047304402206ac44d672dac41f9b00e28f4df20c52eeb087207e8d758d76d92c6fab3b73e2b0220367750dbbe19290069cba53d096f44530e4f98acaa594810388cf7409a1870ce01473044022068c7946a43232757cbdf9176f009a928e1cd9a1a8c212f15c1e11ac9f2925d9002205b75f937ff2f9f3c1246e547e54f62e027f64eefa2695578cc6432cdabce271502473044022059ebf56d98010a932cf8ecfec54c48e6139ed6adb0728c09cbe1e4fa0915302e022007cd986c8fa870ff5d2b3a89139c9fe7e499259875357e20fcbb15571c76795403483045022100fbefd94bd0a488d50b79102b5dad4ab6ced30c4069f1eaa69a4b5a763414067e02203156c6a5c9cf88f91265f5a942e96213afae16d83321c8b31bb342142a14d16381483045022100a5263ea0553ba89221984bd7f0b13613db16e7a70c549a86de0cc0444141a407022005c360ef0ae5a5d4f9f2f87a56c1546cc8268cab08c73501d6b3be2e1e1a8a08824730440220525406a1482936d5a21888260dc165497a90a15669636d8edca6b9fe490d309c022032af0c646a34a44d1f4576bf6a4a74b67940f8faa84c7df9abe12a01a11e2b4783cf56210307b8ae49ac90a048e9b53357a2354b3334e9c8bee813ecb98e99a7e07e8c3ba32103b28f0c28bfab54554ae8c658ac5c3e0ce6e79ad336331f78c428dd43eea8449b21034b8113d703413d57761b8b9781957b8c0ac1dfe69f492580ca4195f50376ba4a21033400f6afecb833092a9a21cfdf1ed1376e58c5d1f47de74683123987e967a8f42103a6d48b1131e94ba04d9737d61acdaa1322008af9602b3b14862c07a1789aac162102d8b661b0b3302ee2f162b09e07a55ad5dfbe673a9f01d9f0c19617681024306b56ae00000000");
     const transaction_accessor tx(decoded_tx, true);
     BOOST_REQUIRE(tx.is_valid());
@@ -515,7 +522,7 @@ BOOST_AUTO_TEST_CASE(script__verify__bip141_p2sh_p2wsh_pushdata1_scriptsig__dirt
     constexpr auto value = 987654321u;
     (*tx.inputs_ptr())[0]->prevout = to_shared(output{ value, { base16_chunk("a9149993a429037b5d912407a71c252019287b8d27a587"), false } });
 
-    BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip141_rule | flags::bip143_rule }, 0), error::dirty_witness);
+    BOOST_REQUIRE_EQUAL(tx.connect({ flags::bip16_rule | flags::bip141_rule | flags::bip143_rule }, 0), error::dirty_embed);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/chain/script_patterns.cpp
+++ b/test/chain/script_patterns.cpp
@@ -585,4 +585,61 @@ BOOST_AUTO_TEST_CASE(script__to_pay_witness_script_hash_pattern__round_trip__seg
     BOOST_REQUIRE(instance.output_pattern() == chain::script_pattern::pay_witness_script_hash);
 }
 
+// is_nominal_push_pattern
+
+// A 22 byte push is nominally encoded by push_size_22 (0x16).
+BOOST_AUTO_TEST_CASE(script__is_nominal_push_pattern__push_size_22__true)
+{
+    const script instance(base16_chunk("16001479091972186c449eb1ded22b78e40d009bdf0089"), false);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_CHECK(script::is_nominal_push_pattern(instance.ops()));
+}
+
+BOOST_AUTO_TEST_CASE(script__is_nominal_push_pattern__push_one_size_22__false)
+{
+    const script instance(base16_chunk("4c16001479091972186c449eb1ded22b78e40d009bdf0089"), false);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_CHECK(!script::is_nominal_push_pattern(instance.ops()));
+}
+
+BOOST_AUTO_TEST_CASE(script__is_nominal_push_pattern__push_two_size_22__false)
+{
+    const script instance(base16_chunk("4d1600001479091972186c449eb1ded22b78e40d009bdf0089"), false);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_CHECK(!script::is_nominal_push_pattern(instance.ops()));
+}
+
+// A 76 byte push is nominally encoded by push_one_size (0x4c).
+BOOST_AUTO_TEST_CASE(script__is_nominal_push_pattern__push_one_size_76__true)
+{
+    const script instance(base16_chunk("4c4c01020304050607080102030405060708010203040506070801020304050607080102030405060708010203040506070801020304050607080102030405060708010203040506070801020304"), false);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_CHECK(script::is_nominal_push_pattern(instance.ops()));
+}
+
+BOOST_AUTO_TEST_CASE(script__is_nominal_push_pattern__push_two_size_76__false)
+{
+    const script instance(base16_chunk("4d4c0001020304050607080102030405060708010203040506070801020304050607080102030405060708010203040506070801020304050607080102030405060708010203040506070801020304"), false);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_CHECK(!script::is_nominal_push_pattern(instance.ops()));
+}
+
+BOOST_AUTO_TEST_CASE(script__is_nominal_push_pattern__two_pushes__false)
+{
+    const script instance(base16_chunk("0016001479091972186c449eb1ded22b78e40d009bdf0089"), false);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_CHECK(!script::is_nominal_push_pattern(instance.ops()));
+}
+
+BOOST_AUTO_TEST_CASE(script__is_nominal_push_pattern__empty__false)
+{
+    BOOST_CHECK(!script::is_nominal_push_pattern(operations{}));
+}
+
+BOOST_AUTO_TEST_CASE(script__is_nominal_push_pattern__non_push__false)
+{
+    const operations ops{ operation{ opcode::checksig } };
+    BOOST_CHECK(!script::is_nominal_push_pattern(ops));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/error/script_error_t.cpp
+++ b/test/error/script_error_t.cpp
@@ -175,6 +175,15 @@ BOOST_AUTO_TEST_CASE(script_error_t__code__dirty_witness__true_expected_message)
     BOOST_REQUIRE_EQUAL(ec.message(), "dirty witness");
 }
 
+BOOST_AUTO_TEST_CASE(script_error_t__code__dirty_embed__true_expected_message)
+{
+    constexpr auto value = error::dirty_embed;
+    const auto ec = code(value);
+    BOOST_REQUIRE(ec);
+    BOOST_REQUIRE(ec == value);
+    BOOST_REQUIRE_EQUAL(ec.message(), "dirty embed");
+}
+
 BOOST_AUTO_TEST_CASE(script_error_t__code__stack_false__true_expected_message)
 {
     constexpr auto value = error::stack_false;


### PR DESCRIPTION
The scriptSig of a p2sh-wrapped witness spend must be byte-exactly a
single nominal push of the embedded script. Only the operation count was
checked, and is_relaxed_push_pattern admits push_one_size/two/four, so a
scriptSig of [4c 16 <22-byte program>] was accepted where Core returns
SCRIPT_ERR_WITNESS_MALLEATED_P2SH. The p2sh hash is unchanged and bip143
does not commit to the scriptSig, so this permitted third party txid
malleation of otherwise valid transactions.
